### PR TITLE
Merge Labled dataset

### DIFF
--- a/pytoda/data_splitter.py
+++ b/pytoda/data_splitter.py
@@ -10,9 +10,14 @@ from .types import FileList
 
 
 def csv_data_splitter(
-    data_filepaths: FileList, save_path: str, data_type: str,
-    mode: str, seed: int = 42, test_fraction: float = 0.1,
-    number_of_columns: int = 12, **kwargs
+    data_filepaths: FileList,
+    save_path: str,
+    data_type: str,
+    mode: str,
+    seed: int = 42,
+    test_fraction: float = 0.1,
+    number_of_columns: int = 12,
+    **kwargs
 ) -> Tuple[str, str]:
     """
     Function for generic splitting into train and test data in csv format..
@@ -36,7 +41,9 @@ def csv_data_splitter(
     """
     # preparation
     random.seed(seed)
-    data_filepaths = [data_filepaths] if isinstance(data_filepaths, str) else data_filepaths
+    data_filepaths = [data_filepaths] if isinstance(
+        data_filepaths, str
+    ) else data_filepaths   # yapf:disable
     file_suffix = '{}_{}_fraction_{}_id_{}_seed_{}.csv'
     hash_fn = hashlib.md5()
     if not ('index_col' in kwargs):
@@ -46,9 +53,11 @@ def csv_data_splitter(
     # but only consider first number_of_columns columns (slow otherwise)
     def _hash_from_df_columns(df, number_of_columns):
         return (
-            df.reindex(sorted(df.columns), axis=1).
-            to_string(columns=sorted(df.columns)[:number_of_columns])
+            df.reindex(sorted(df.columns), axis=1).to_string(
+                columns=sorted(df.columns)[:number_of_columns]
+            )
         )
+
     # NOTE: if all *.csv files contain a single sample only
     # the splitting modes collapse
     # file splitting mode
@@ -60,24 +69,28 @@ def csv_data_splitter(
         file_indexes = np.arange(len(data_filepaths))
         random.shuffle(file_indexes)
         # compile splits (ceil ensures test_df is not empty)
-        test_df = pd.concat([
-            pd.read_csv(data_filepaths[index], **kwargs)
-            for index in file_indexes[:ceil(test_fraction*len(data_filepaths))]
-        ])
-        train_df = pd.concat([
-            pd.read_csv(data_filepaths[index], **kwargs)
-            for index in file_indexes[ceil(test_fraction*len(data_filepaths)):]
-        ])
+        test_df = pd.concat(
+            [
+                pd.read_csv(data_filepaths[index], **kwargs) for index in
+                file_indexes[:ceil(test_fraction * len(data_filepaths))]
+            ]
+        )
+        train_df = pd.concat(
+            [
+                pd.read_csv(data_filepaths[index], **kwargs) for index in
+                file_indexes[ceil(test_fraction * len(data_filepaths)):]
+            ]
+        )
     # random splitting mode:
     # build a joint df from all samples, then split
     elif mode == 'random':
-        df = pd.concat([
-            pd.read_csv(data_path, **kwargs)
-            for data_path in data_filepaths
-        ], sort=False)
+        df = pd.concat(
+            [pd.read_csv(data_path, **kwargs) for data_path in data_filepaths],
+            sort=False
+        )
         sample_indexes = np.arange(df.shape[0])
         random.shuffle(sample_indexes)
-        splitting_index = ceil(test_fraction*df.shape[0])
+        splitting_index = ceil(test_fraction * df.shape[0])
         test_df = df.iloc[sample_indexes[:splitting_index]]
         train_df = df.iloc[sample_indexes[splitting_index:]]
     else:
@@ -98,16 +111,12 @@ def csv_data_splitter(
     train_filepath = os.path.join(
         save_path,
         file_suffix.format(
-            data_type, 'train', 1 - test_fraction,
-            hash_id, seed
+            data_type, 'train', 1 - test_fraction, hash_id, seed
         )
     )
     test_filepath = os.path.join(
         save_path,
-        file_suffix.format(
-            data_type, 'test', test_fraction,
-            hash_id, seed
-        )
+        file_suffix.format(data_type, 'test', test_fraction, hash_id, seed)
     )
     # write the dataset
     for path, df in zip([train_filepath, test_filepath], [train_df, test_df]):

--- a/pytoda/datasets/__init__.py
+++ b/pytoda/datasets/__init__.py
@@ -2,3 +2,4 @@
 from .smiles_dataset import SMILESDataset  # noqa
 from .gene_expression_dataset import GeneExpressionDataset  # noqa
 from .drug_sensitivity_dataset import DrugSensitivityDataset  # noqa
+from .annotated_dataset import AnnotatedDataset  # noqa

--- a/pytoda/datasets/annotated_dataset.py
+++ b/pytoda/datasets/annotated_dataset.py
@@ -21,15 +21,15 @@ class AnnotatedDataset(Dataset):
     ) -> None:
         """
         Initialize an annotated dataset.
-        E.g. the  samples could be SMILES and the annotations a single or
-        multiple labels.
+        E.g. the  input_data could be SMILES and the annotations could be
+        single or multi task labels.
 
         Args:
             annotations_filepath (str): path to the annotations of a dataset
-                .csv file. Currently, the only supported format is .csv,
-                with an index and three header columns named: "drug",
-                "cell_line", "IC50".
-            data (Dataset): path to .smi file.
+                .csv file. Currently, the only supported format is .csv, the
+                last column should point to an ID that is also contained in
+                input_data.
+            input_data (Dataset): path to .smi file.
             smiles_langśage (SMILESLanguage): a smiles language.
                 Defaults to None.
             device (torch.device): device where the tensors are stored.
@@ -56,6 +56,7 @@ class AnnotatedDataset(Dataset):
 
         # Multilabel classification case
         self.num_tasks = len(self.annotated_data_df.columns) - 1
+        self.id_column_name = self.annotated_data_df.columns[-1]
 
     def __len__(self) -> int:
         "Total number of samples."
@@ -82,6 +83,8 @@ class AnnotatedDataset(Dataset):
         )
         # e.g. SMILES
         token_indexes_tensor = self.input_data[
-            self.input_data.sample_to_index_mapping[selected_sample['mol_id']]
+            self.input_data.sample_to_index_mapping[
+                selected_sample[self.id_column_name]
+            ]
         ]   # yapf: disable
         return token_indexes_tensor, labels_tensor

--- a/pytoda/datasets/annotated_dataset.py
+++ b/pytoda/datasets/annotated_dataset.py
@@ -50,10 +50,6 @@ class AnnotatedDataset(Dataset):
         # e.g. SMILES
         self.input_data = input_data
 
-        # TODO: This is not so great since it does not catch cases with
-        # conflicts/missing values in between of input_data and annotations.
-        self.number_of_samples = self.input_data.__len__()
-
         self.annotated_data_df = pd.read_csv(
             self.annotations_filepath, index_col=0, **kwargs
         )
@@ -63,7 +59,7 @@ class AnnotatedDataset(Dataset):
 
     def __len__(self) -> int:
         "Total number of samples."
-        return self.number_of_samples
+        return len(self.annotated_data_df)
 
     def __getitem__(self, index: int) -> DrugSensitivityData:
         """
@@ -80,7 +76,7 @@ class AnnotatedDataset(Dataset):
         # Labels
         selected_sample = self.annotated_data_df.iloc[index]
         labels_tensor = torch.tensor(
-            list(selected_sample[:self.num_tasks - 1].values),
+            list(selected_sample[:self.num_tasks].values),
             dtype=torch.float,
             device=self.device
         )

--- a/pytoda/datasets/annotated_dataset.py
+++ b/pytoda/datasets/annotated_dataset.py
@@ -1,0 +1,91 @@
+"""Implementation of AnnotatedDataset class."""
+import torch
+import pandas as pd
+from torch.utils.data import Dataset
+from ..types import DrugSensitivityData
+
+
+class AnnotatedDataset(Dataset):
+    """
+    Annotated dataset implementation.
+    """
+
+    def __init__(
+        self,
+        annotations_filepath: str,
+        input_data: Dataset,
+        device: torch.device = torch.
+        device('cuda' if torch.cuda.is_available() else 'cpu'),
+        backend: str = 'eager',
+        **kwargs
+    ) -> None:
+        """
+        Initialize an annotated dataset.
+        E.g. the  samples could be SMILES and the annotations a single or
+        multiple labels.
+
+        Args:
+            annotations_filepath (str): path to the annotations of a dataset
+                .csv file. Currently, the only supported format is .csv,
+                with an index and three header columns named: "drug",
+                "cell_line", "IC50".
+            data (Dataset): path to .smi file.
+            smiles_langśage (SMILESLanguage): a smiles language.
+                Defaults to None.
+            device (torch.device): device where the tensors are stored.
+                Defaults to gpu, if available.
+            backend (str): memeory management backend.
+                Defaults to eager, prefer speed over memory consumption.
+                Note that at the moment only the gene expression and the
+                smiles datasets implement both backends. The drug sensitivity
+                data are loaded in memory.
+            kwargs (dict): additional parameters for pd.read_csv.
+        """
+        Dataset.__init__(self)
+        self.annotations_filepath = annotations_filepath
+        # device
+        self.device = device
+        # backend
+        self.backend = backend
+        # e.g. SMILES
+        self.input_data = input_data
+
+        # TODO: This is not so great since it does not catch cases with
+        # conflicts/missing values in between of input_data and annotations.
+        self.number_of_samples = self.input_data.__len__()
+
+        self.annotated_data_df = pd.read_csv(
+            self.annotations_filepath, index_col=0, **kwargs
+        )
+
+        # Multilabel classification case
+        self.num_tasks = len(self.annotated_data_df.columns) - 1
+
+    def __len__(self) -> int:
+        "Total number of samples."
+        return self.number_of_samples
+
+    def __getitem__(self, index: int) -> DrugSensitivityData:
+        """
+        Generates one sample of data.
+
+        Args:
+            index (int): index of the sample to fetch.
+
+        Returns:
+            DrugSensitivityData: a tuple containing three torch.tensors,
+                representing respetively: compound token indexes,
+                gene expression values and IC50 for the current sample.
+        """
+        # Labels
+        selected_sample = self.annotated_data_df.iloc[index]
+        labels_tensor = torch.tensor(
+            list(selected_sample[:self.num_tasks - 1].values),
+            dtype=torch.float,
+            device=self.device
+        )
+        # e.g. SMILES
+        token_indexes_tensor = self.input_data[
+            self.input_data.sample_to_index_mapping[selected_sample['mol_id']]
+        ]   # yapf: disable
+        return token_indexes_tensor, labels_tensor

--- a/pytoda/datasets/annotated_dataset.py
+++ b/pytoda/datasets/annotated_dataset.py
@@ -14,6 +14,7 @@ class AnnotatedDataset(Dataset):
         self,
         annotations_filepath: str,
         input_data: Dataset,
+        index_col: int,
         device: torch.device = torch.
         device('cuda' if torch.cuda.is_available() else 'cpu'),
         backend: str = 'eager',
@@ -30,6 +31,7 @@ class AnnotatedDataset(Dataset):
                 last column should point to an ID that is also contained in
                 input_data.
             input_data (Dataset): path to .smi file.
+            index_col (int): index column of annotations_filepath csv file
             smiles_langśage (SMILESLanguage): a smiles language.
                 Defaults to None.
             device (torch.device): device where the tensors are stored.
@@ -51,7 +53,7 @@ class AnnotatedDataset(Dataset):
         self.input_data = input_data
 
         self.annotated_data_df = pd.read_csv(
-            self.annotations_filepath, index_col=0, **kwargs
+            self.annotations_filepath, index_col=index_col, **kwargs
         )
 
         # Multilabel classification case


### PR DESCRIPTION
added abstract class for labeled dataset, called `AnnotatedDataset`, found under `pytoda.datasets.annotated_dataset`:

- receives  a `torch.utils.data.dataset` object, e.g. a previously instantiated child object of type `SMILESDataset`
- receives a path to a `csv` file with labels. The labels can be multi task but since the amount of tasks is dynamically inferred, the labels in a multi class (but single task) case (like MNIST) *should not be defined as one-hot vectors*.
- The last column of the label-csv file needs to contain IDs that are also contained in the associated `dataset` object (similar to `drug_sensitivity_dataset`)

Yapfed some other files on the fly.

@drugilsberg, not sure this can handle SMILES augmentation on the fly. If so, it should be done by `sample_to_index_mapping`. Any idea on this?