### PR TITLE
Updating SMILES features functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ For some examples on how to use `pytoda` see [here](./examples)
 If you use `pytoda` in your projects, please cite the following:
 
 ```bib
-@misc{born2019reinforcement,
-    title={Reinforcement learning-driven de-novo design of anticancer compounds conditioned on biomolecular profiles},
-    author={Jannis Born and Matteo Manica and Ali Oskooei and Maria Rodriguez Martinez},
+@misc{born2019paccmannrl,
+    title={PaccMann^RL: Designing anticancer drugs from transcriptomic data via reinforcement learning},
+    author={Jannis Born and Matteo Manica and Ali Oskooei and Joris Cadow and María Rodríguez Martínez},
     year={2019},
     eprint={1909.05114},
     archivePrefix={arXiv},

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ If you use `pytoda` in your projects, please cite the following:
 ```bib
 @misc{born2019paccmannrl,
     title={PaccMann^RL: Designing anticancer drugs from transcriptomic data via reinforcement learning},
-    author={Jannis Born and Matteo Manica and Ali Oskooei and Joris Cadow and María Rodríguez Martínez},
+    author={Jannis Born and Matteo Manica and Ali Oskooei and Joris Cadow and Maria Rodriguez Martinez},
     year={2019},
     eprint={1909.05114},
     archivePrefix={arXiv},

--- a/conda.yml
+++ b/conda.yml
@@ -12,3 +12,4 @@ dependencies:
     - torch==1.0.1
     - diskcache==4.1.0
     - dill==0.3.1.1
+    - selfies==0.2.4

--- a/pytoda/__init__.py
+++ b/pytoda/__init__.py
@@ -1,2 +1,2 @@
 name = 'pytoda'
-__version__ = '0.0.1'
+__version__ = '0.0.2'

--- a/pytoda/datasets/_smiles_dataset.py
+++ b/pytoda/datasets/_smiles_dataset.py
@@ -135,6 +135,7 @@ class _SMILESDataset(Dataset):
             _transforms += [Selfies()]
 
         self.language_transforms = Compose(_transforms)
+        self._setup_dataset()
         transforms = _transforms.copy()
         transforms += [
             SMILESToTokenIndexes(smiles_language=self.smiles_language)
@@ -142,6 +143,8 @@ class _SMILESDataset(Dataset):
         if self.randomize:
             transforms += [Randomize()]
         if self.padding:
+            if padding_length is None:
+                self.padding_length = self.smiles_language.max_token_sequence_length
             transforms += [
                 LeftPadding(
                     padding_length=self.padding_length,
@@ -150,10 +153,7 @@ class _SMILESDataset(Dataset):
             ]
         transforms += [ToTensor(device=self.device)]
         self.transform = Compose(transforms)
-        self._dataset = None
-        # NOTE: the dataset will be initialized and designed to return SMILES
-        #       strings
-        self._setup_dataset()
+
         # NOTE: recover sample and index mappings
         self.sample_to_index_mapping = {}
         self.index_to_sample_mapping = {}

--- a/pytoda/datasets/_smiles_dataset.py
+++ b/pytoda/datasets/_smiles_dataset.py
@@ -1,6 +1,4 @@
 """Implementation of _SMILESDataset."""
-from copy import deepcopy
-
 import torch
 from torch.utils.data import Dataset
 
@@ -138,7 +136,7 @@ class _SMILESDataset(Dataset):
 
         self.language_transforms = Compose(_transforms)
         self._setup_dataset()
-        transforms = deepcopy(_transforms)
+        transforms = _transforms.copy()
         transforms += [
             SMILESToTokenIndexes(smiles_language=self.smiles_language)
         ]

--- a/pytoda/datasets/_smiles_dataset.py
+++ b/pytoda/datasets/_smiles_dataset.py
@@ -1,4 +1,6 @@
 """Implementation of _SMILESDataset."""
+from copy import deepcopy
+
 import torch
 from torch.utils.data import Dataset
 
@@ -136,7 +138,7 @@ class _SMILESDataset(Dataset):
 
         self.language_transforms = Compose(_transforms)
         self._setup_dataset()
-        transforms = _transforms.copy()
+        transforms = deepcopy(_transforms)
         transforms += [
             SMILESToTokenIndexes(smiles_language=self.smiles_language)
         ]

--- a/pytoda/datasets/_smiles_eager_dataset.py
+++ b/pytoda/datasets/_smiles_eager_dataset.py
@@ -29,6 +29,7 @@ class _SMILESEagerDataset(_SMILESDataset):
         randomize: bool = False,
         remove_bonddir: bool = False,
         remove_chirality: bool = False,
+        selfies: bool = False,
         device: torch.device = torch.
         device('cuda' if torch.cuda.is_available() else 'cpu')
     ) -> None:
@@ -58,6 +59,8 @@ class _SMILESEagerDataset(_SMILESDataset):
                 Defaults to False.
             remove_chirality (bool): Remove chirality information.
                 Defaults to False.
+            selfies (bool): Whether selfies is used instead of smiles, defaults
+                to False.
             device (torch.device): device where the tensors are stored.
                 Defaults to gpu, if available.
         """
@@ -73,6 +76,7 @@ class _SMILESEagerDataset(_SMILESDataset):
             randomize=randomize,
             remove_bonddir=remove_bonddir,
             remove_chirality=remove_chirality,
+            selfies=selfies,
             device=device
         )
 
@@ -84,5 +88,5 @@ class _SMILESEagerDataset(_SMILESDataset):
         # Run once over dataset to add missing tokens to smiles language
         for index in range(len(self._dataset)):
             self.smiles_language.add_smiles(
-                self.smiles_transforms(self._dataset[index])
+                self.language_transforms(self._dataset[index])
             )

--- a/pytoda/datasets/_smiles_eager_dataset.py
+++ b/pytoda/datasets/_smiles_eager_dataset.py
@@ -23,6 +23,12 @@ class _SMILESEagerDataset(_SMILESDataset):
         padding_length: int = None,
         add_start_and_stop: bool = False,
         augment: bool = False,
+        kekulize: bool = False,
+        allBondsExplicit: bool = False,
+        allHsExplicit: bool = False,
+        randomize: bool = False,
+        remove_bonddir: bool = False,
+        remove_chirality: bool = False,
         device: torch.device = torch.
         device('cuda' if torch.cuda.is_available() else 'cpu')
     ) -> None:
@@ -40,6 +46,18 @@ class _SMILESEagerDataset(_SMILESDataset):
             add_start_and_stop (bool): add start and stop token indexes.
                 Defaults to False.
             augment (bool): perform SMILES augmentation. Defaults to False.
+            kekulize (bool): kekulizes SMILES (implicit aromaticity only).
+                Defaults to False.
+            allBondsExplicit (bool): Makes all bonds explicit. Defaults to
+                False, only applies if kekulize = True.
+            allHsExplicit (bool): Makes all hydrogens explicit. Defaults to
+                False, only applies if kekulize = True.
+            randomize (bool): perform a true randomization of SMILES tokens.
+                Defaults to False.
+            remove_bonddir (bool): Remove directional info of bonds.
+                Defaults to False.
+            remove_chirality (bool): Remove chirality information.
+                Defaults to False.
             device (torch.device): device where the tensors are stored.
                 Defaults to gpu, if available.
         """
@@ -49,6 +67,12 @@ class _SMILESEagerDataset(_SMILESDataset):
             padding=padding,
             add_start_and_stop=add_start_and_stop,
             augment=augment,
+            kekulize=kekulize,
+            allBondsExplicit=allBondsExplicit,
+            allHsExplicit=allHsExplicit,
+            randomize=randomize,
+            remove_bonddir=remove_bonddir,
+            remove_chirality=remove_chirality,
             device=device
         )
 
@@ -57,3 +81,8 @@ class _SMILESEagerDataset(_SMILESDataset):
         self._dataset = concatenate_file_based_datasets(
             filepaths=self.smi_filepaths, dataset_class=_SmiEagerDataset
         )
+        # Run once over dataset to add missing tokens to smiles language
+        for index in range(len(self._dataset)):
+            self.smiles_language.add_smiles(
+                self.smiles_transforms(self._dataset[index])
+            )

--- a/pytoda/datasets/_smiles_lazy_dataset.py
+++ b/pytoda/datasets/_smiles_lazy_dataset.py
@@ -30,6 +30,7 @@ class _SMILESLazyDataset(_SMILESDataset):
         randomize: bool = False,
         remove_bonddir: bool = False,
         remove_chirality: bool = False,
+        selfies: bool = False,
         device: torch.device = torch.
         device('cuda' if torch.cuda.is_available() else 'cpu'),
         chunk_size: int = 10000
@@ -60,6 +61,8 @@ class _SMILESLazyDataset(_SMILESDataset):
                 Defaults to False.
             remove_chirality (bool): Remove chirality information.
                 Defaults to False.
+            selfies (bool): Whether selfies is used instead of smiles, defaults
+                to False.
             device (torch.device): device where the tensors are stored.
                 Defaults to gpu, if available.
             chunk_size (int): size of the chunks. Defauls to 10000.
@@ -77,6 +80,7 @@ class _SMILESLazyDataset(_SMILESDataset):
             randomize=randomize,
             remove_bonddir=remove_bonddir,
             remove_chirality=remove_chirality,
+            selfies=selfies,
             device=device
         )
 
@@ -90,5 +94,5 @@ class _SMILESLazyDataset(_SMILESDataset):
         # Run once over dataset to add missing tokens to smiles language
         for index in range(len(self._dataset)):
             self.smiles_language.add_smiles(
-                self.smiles_transforms(self._dataset[index])
+                self.language_transforms(self._dataset[index])
             )

--- a/pytoda/datasets/_smiles_lazy_dataset.py
+++ b/pytoda/datasets/_smiles_lazy_dataset.py
@@ -24,6 +24,12 @@ class _SMILESLazyDataset(_SMILESDataset):
         padding_length: int = None,
         add_start_and_stop: bool = False,
         augment: bool = False,
+        kekulize: bool = False,
+        allBondsExplicit: bool = False,
+        allHsExplicit: bool = False,
+        randomize: bool = False,
+        remove_bonddir: bool = False,
+        remove_chirality: bool = False,
         device: torch.device = torch.
         device('cuda' if torch.cuda.is_available() else 'cpu'),
         chunk_size: int = 10000
@@ -42,6 +48,18 @@ class _SMILESLazyDataset(_SMILESDataset):
             add_start_and_stop (bool): add start and stop token indexes.
                 Defaults to False.
             augment (bool): perform SMILES augmentation. Defaults to False.
+            kekulize (bool): kekulizes SMILES (implicit aromaticity only).
+                Defaults to False.
+            allBondsExplicit (bool): Makes all bonds explicit. Defaults to
+                False, only applies if kekulize = True.
+            allHsExplicit (bool): Makes all hydrogens explicit. Defaults to
+                False, only applies if kekulize = True.
+            randomize (bool): perform a true randomization of SMILES tokens.
+                Defaults to False.
+            remove_bonddir (bool): Remove directional info of bonds.
+                Defaults to False.
+            remove_chirality (bool): Remove chirality information.
+                Defaults to False.
             device (torch.device): device where the tensors are stored.
                 Defaults to gpu, if available.
             chunk_size (int): size of the chunks. Defauls to 10000.
@@ -53,6 +71,12 @@ class _SMILESLazyDataset(_SMILESDataset):
             padding=padding,
             add_start_and_stop=add_start_and_stop,
             augment=augment,
+            kekulize=kekulize,
+            allBondsExplicit=allBondsExplicit,
+            allHsExplicit=allHsExplicit,
+            randomize=randomize,
+            remove_bonddir=remove_bonddir,
+            remove_chirality=remove_chirality,
             device=device
         )
 
@@ -63,3 +87,8 @@ class _SMILESLazyDataset(_SMILESDataset):
             dataset_class=_SmiLazyDataset,
             chunk_size=self.chunk_size
         )
+        # Run once over dataset to add missing tokens to smiles language
+        for index in range(len(self._dataset)):
+            self.smiles_language.add_smiles(
+                self.smiles_transforms(self._dataset[index])
+            )

--- a/pytoda/datasets/smiles_dataset.py
+++ b/pytoda/datasets/smiles_dataset.py
@@ -25,6 +25,12 @@ class SMILESDataset(Dataset):
         padding_length: int = None,
         add_start_and_stop: bool = False,
         augment: bool = False,
+        kekulize: bool = False,
+        allBondsExplicit: bool = False,
+        allHsExplicit: bool = False,
+        randomize: bool = False,
+        remove_bonddir: bool = False,
+        remove_chirality: bool = False,
         device: torch.device = torch.
         device('cuda' if torch.cuda.is_available() else 'cpu'),
         backend: str = 'eager'
@@ -43,6 +49,18 @@ class SMILESDataset(Dataset):
             add_start_and_stop (bool): add start and stop token indexes.
                 Defaults to False.
             augment (bool): perform SMILES augmentation. Defaults to False.
+            kekulize (bool): kekulizes SMILES (implicit aromaticity only).
+                Defaults to False.
+            allBondsExplicit (bool): Makes all bonds explicit. Defaults to
+                False, only applies if kekulize = True.
+            allHsExplicit (bool): Makes all hydrogens explicit. Defaults to
+                False, only applies if kekulize = True.
+            randomize (bool): perform a true randomization of SMILES tokens.
+                Defaults to False.
+            remove_bonddir (bool): Remove directional info of bonds.
+                Defaults to False.
+            remove_chirality (bool): Remove chirality information.
+                Defaults to False.
             device (torch.device): device where the tensors are stored.
                 Defaults to gpu, if available.
             backend (str): memeory management backend.
@@ -61,6 +79,12 @@ class SMILESDataset(Dataset):
             padding=padding,
             add_start_and_stop=add_start_and_stop,
             augment=augment,
+            kekulize=kekulize,
+            allBondsExplicit=allBondsExplicit,
+            allHsExplicit=allHsExplicit,
+            randomize=randomize,
+            remove_bonddir=remove_bonddir,
+            remove_chirality=remove_chirality,
             device=device
         )
         self.smiles_language = self._dataset.smiles_language

--- a/pytoda/datasets/smiles_dataset.py
+++ b/pytoda/datasets/smiles_dataset.py
@@ -31,6 +31,7 @@ class SMILESDataset(Dataset):
         randomize: bool = False,
         remove_bonddir: bool = False,
         remove_chirality: bool = False,
+        selfies: bool = False,
         device: torch.device = torch.
         device('cuda' if torch.cuda.is_available() else 'cpu'),
         backend: str = 'eager'
@@ -61,6 +62,8 @@ class SMILESDataset(Dataset):
                 Defaults to False.
             remove_chirality (bool): Remove chirality information.
                 Defaults to False.
+            selfies (bool): Whether selfies is used instead of smiles, defaults
+                to False.
             device (torch.device): device where the tensors are stored.
                 Defaults to gpu, if available.
             backend (str): memeory management backend.
@@ -85,6 +88,7 @@ class SMILESDataset(Dataset):
             randomize=randomize,
             remove_bonddir=remove_bonddir,
             remove_chirality=remove_chirality,
+            selfies=selfies,
             device=device
         )
         self.smiles_language = self._dataset.smiles_language

--- a/pytoda/datasets/tests/test_smiles_eager_dataset.py
+++ b/pytoda/datasets/tests/test_smiles_eager_dataset.py
@@ -44,22 +44,33 @@ class TestSMILESDatasetEagerBackend(unittest.TestCase):
                 smiles_dataset = SMILESDataset(
                     a_test_file.filename,
                     another_test_file.filename,
+                    padding=True,
+                    augment=False,
+                    kekulize=True,
+                    allBondsExplicit=True,
+                    remove_chirality=True,
                     backend='eager'
                 )
-                padding_index = smiles_dataset.smiles_language.padding_index
+                pad_index = smiles_dataset.smiles_language.padding_index
                 start_index = smiles_dataset.smiles_language.start_index
                 stop_index = smiles_dataset.smiles_language.stop_index
                 c_index = smiles_dataset.smiles_language.token_to_index['C']
                 o_index = smiles_dataset.smiles_language.token_to_index['O']
                 n_index = smiles_dataset.smiles_language.token_to_index['N']
                 s_index = smiles_dataset.smiles_language.token_to_index['S']
+                d_index = smiles_dataset.smiles_language.token_to_index['-']
+
                 self.assertListEqual(
-                    smiles_dataset[0].numpy().flatten().tolist(),
-                    [padding_index, c_index, c_index, o_index]
+                    smiles_dataset[0].numpy().flatten().tolist(), [
+                        pad_index, pad_index, c_index, d_index, c_index,
+                        d_index, o_index
+                    ]
                 )
                 self.assertListEqual(
-                    smiles_dataset[7].numpy().flatten().tolist(),
-                    [n_index, c_index, c_index, s_index]
+                    smiles_dataset[7].numpy().flatten().tolist(), [
+                        n_index, d_index, c_index, d_index, c_index, d_index,
+                        s_index
+                    ]
                 )
                 smiles_dataset = SMILESDataset(
                     a_test_file.filename,
@@ -83,7 +94,7 @@ class TestSMILESDatasetEagerBackend(unittest.TestCase):
                 )
                 self.assertListEqual(
                     smiles_dataset[0].numpy().flatten().tolist(), [
-                        padding_index, start_index, c_index, c_index, o_index,
+                        pad_index, start_index, c_index, c_index, o_index,
                         stop_index
                     ]
                 )
@@ -111,6 +122,31 @@ class TestSMILESDatasetEagerBackend(unittest.TestCase):
                         token_indexes_to_smiles(token_indexes)
                     )
                     self.assertEqual(smiles, randomized_smiles)
+
+                smiles_dataset = SMILESDataset(
+                    a_test_file.filename,
+                    another_test_file.filename,
+                    padding=False,
+                    add_start_and_stop=True,
+                    remove_bonddir=True,
+                    selfies=True,
+                    backend='eager'
+                )
+                c_index = smiles_dataset.smiles_language.token_to_index['[C]']
+                o_index = smiles_dataset.smiles_language.token_to_index['[O]']
+                n_index = smiles_dataset.smiles_language.token_to_index['[N]']
+                s_index = smiles_dataset.smiles_language.token_to_index['[S]']
+
+                self.assertListEqual(
+                    smiles_dataset[0].numpy().flatten().tolist(),
+                    [start_index, c_index, c_index, o_index, stop_index]
+                )
+                self.assertListEqual(
+                    smiles_dataset[7].numpy().flatten().tolist(), [
+                        start_index, n_index, c_index, c_index, s_index,
+                        stop_index
+                    ]
+                )
 
     def test_data_loader(self) -> None:
         """Test data_loader."""

--- a/pytoda/datasets/tests/test_smiles_eager_dataset.py
+++ b/pytoda/datasets/tests/test_smiles_eager_dataset.py
@@ -101,7 +101,7 @@ class TestSMILESDatasetEagerBackend(unittest.TestCase):
                 )
                 np.random.seed(0)
                 for randomized_smiles in [
-                    'CSCN', 'NCCS', 'SCCN', 'CNCS', 'CCSN'
+                    'C(S)CN', 'NCCS', 'SCCN', 'C(N)CS', 'C(CS)N'
                 ]:
                     token_indexes = (
                         smiles_dataset[3].numpy().flatten().tolist()

--- a/pytoda/datasets/tests/test_smiles_lazy_dataset.py
+++ b/pytoda/datasets/tests/test_smiles_lazy_dataset.py
@@ -44,22 +44,33 @@ class TestSMILESDatasetLazyBackend(unittest.TestCase):
                 smiles_dataset = SMILESDataset(
                     a_test_file.filename,
                     another_test_file.filename,
+                    padding=True,
+                    augment=False,
+                    kekulize=True,
+                    allBondsExplicit=True,
+                    remove_chirality=True,
                     backend='lazy'
                 )
-                padding_index = smiles_dataset.smiles_language.padding_index
+                pad_index = smiles_dataset.smiles_language.padding_index
                 start_index = smiles_dataset.smiles_language.start_index
                 stop_index = smiles_dataset.smiles_language.stop_index
                 c_index = smiles_dataset.smiles_language.token_to_index['C']
                 o_index = smiles_dataset.smiles_language.token_to_index['O']
                 n_index = smiles_dataset.smiles_language.token_to_index['N']
                 s_index = smiles_dataset.smiles_language.token_to_index['S']
+                d_index = smiles_dataset.smiles_language.token_to_index['-']
+
                 self.assertListEqual(
-                    smiles_dataset[0].numpy().flatten().tolist(),
-                    [padding_index, c_index, c_index, o_index]
+                    smiles_dataset[0].numpy().flatten().tolist(), [
+                        pad_index, pad_index, c_index, d_index, c_index,
+                        d_index, o_index
+                    ]
                 )
                 self.assertListEqual(
-                    smiles_dataset[7].numpy().flatten().tolist(),
-                    [n_index, c_index, c_index, s_index]
+                    smiles_dataset[7].numpy().flatten().tolist(), [
+                        n_index, d_index, c_index, d_index, c_index, d_index,
+                        s_index
+                    ]
                 )
                 smiles_dataset = SMILESDataset(
                     a_test_file.filename,
@@ -83,7 +94,7 @@ class TestSMILESDatasetLazyBackend(unittest.TestCase):
                 )
                 self.assertListEqual(
                     smiles_dataset[0].numpy().flatten().tolist(), [
-                        padding_index, start_index, c_index, c_index, o_index,
+                        pad_index, start_index, c_index, c_index, o_index,
                         stop_index
                     ]
                 )
@@ -111,6 +122,31 @@ class TestSMILESDatasetLazyBackend(unittest.TestCase):
                         token_indexes_to_smiles(token_indexes)
                     )
                     self.assertEqual(smiles, randomized_smiles)
+
+                smiles_dataset = SMILESDataset(
+                    a_test_file.filename,
+                    another_test_file.filename,
+                    padding=False,
+                    add_start_and_stop=True,
+                    remove_bonddir=True,
+                    selfies=True,
+                    backend='lazy'
+                )
+                c_index = smiles_dataset.smiles_language.token_to_index['[C]']
+                o_index = smiles_dataset.smiles_language.token_to_index['[O]']
+                n_index = smiles_dataset.smiles_language.token_to_index['[N]']
+                s_index = smiles_dataset.smiles_language.token_to_index['[S]']
+
+                self.assertListEqual(
+                    smiles_dataset[0].numpy().flatten().tolist(),
+                    [start_index, c_index, c_index, o_index, stop_index]
+                )
+                self.assertListEqual(
+                    smiles_dataset[7].numpy().flatten().tolist(), [
+                        start_index, n_index, c_index, c_index, s_index,
+                        stop_index
+                    ]
+                )
 
     def test_data_loader(self) -> None:
         """Test data_loader."""

--- a/pytoda/datasets/tests/test_smiles_lazy_dataset.py
+++ b/pytoda/datasets/tests/test_smiles_lazy_dataset.py
@@ -101,7 +101,7 @@ class TestSMILESDatasetLazyBackend(unittest.TestCase):
                 )
                 np.random.seed(0)
                 for randomized_smiles in [
-                    'CSCN', 'NCCS', 'SCCN', 'CNCS', 'CCSN'
+                    'C(S)CN', 'NCCS', 'SCCN', 'C(N)CS', 'C(CS)N'
                 ]:
                     token_indexes = (
                         smiles_dataset[3].numpy().flatten().tolist()

--- a/pytoda/smiles/processing.py
+++ b/pytoda/smiles/processing.py
@@ -11,50 +11,22 @@ SMILES_TOKENIZER = re.compile(
 SMILES_NORMALIZER = re.compile(r'-(\w)')
 # smiles normalization dictionary
 
-# TODO: This does not seem right
-SMILES_NORMALIZATION_DICTIONARY = str.maketrans(
-    {
-        'c': 'C',
-        'n': 'N',
-        'h': 'H',
-        's': 'S',
-        'o': 'O'
-    }
-)
-
-
-def apply_normalization_dictionary(smiles: str) -> str:
-    """
-    Apply a SMILES normalization dictionary. If applied, the SMILES is
-    not case-sensitive (blind to aromatic vs. aliphatic structures)
-
-    Args:
-        smiles (str): a SMILES representation.
-
-    Returns:
-        str: SMILES normalized using `SMILES_NORMALIZATION_DICTIONARY`.
-    """
-    return SMILES_NORMALIZER.sub(
-        r'\1', smiles.translate(SMILES_NORMALIZATION_DICTIONARY)
-    )
-
 
 def tokenize_smiles(smiles: str, normalize=False) -> Tokens:
     """
-    Tokenize SMILES after (optionally) normalizing it.
+    Tokenize a character-level SMILES string.
 
     Args:
         smiles (str): a SMILES representation.
         normalize (bool): whether normalization is done.
+        
+        NOTE: The `normalize` argument is deprecated and will be removed in a
+        future release.
 
     Returns:
-        Tokens: the tokenized SMILES after an optional normalization.
+        Tokens: the tokenized SMILES.
     """
-    return [
-        token for token in SMILES_TOKENIZER.
-        split(apply_normalization_dictionary(smiles) if normalize else smiles)
-        if token
-    ]
+    return [token for token in SMILES_TOKENIZER.split(smiles) if token]
 
 
 def tokenize_selfies(selfies: str) -> Tokens:

--- a/pytoda/smiles/processing.py
+++ b/pytoda/smiles/processing.py
@@ -11,7 +11,7 @@ SMILES_TOKENIZER = re.compile(
 SMILES_NORMALIZER = re.compile(r'-(\w)')
 # smiles normalization dictionary
 
-# TODO: To be replaced by explicitly encoding aromatic structures
+# TODO: This does not seem right
 SMILES_NORMALIZATION_DICTIONARY = str.maketrans(
     {
         'c': 'C',

--- a/pytoda/smiles/processing.py
+++ b/pytoda/smiles/processing.py
@@ -9,7 +9,6 @@ SMILES_TOKENIZER = re.compile(
 )
 # handle "-" character
 SMILES_NORMALIZER = re.compile(r'-(\w)')
-# smiles normalization dictionary
 
 
 def tokenize_smiles(smiles: str, normalize=False) -> Tokens:

--- a/pytoda/smiles/processing.py
+++ b/pytoda/smiles/processing.py
@@ -55,3 +55,24 @@ def tokenize_smiles(smiles: str, normalize=False) -> Tokens:
         split(apply_normalization_dictionary(smiles) if normalize else smiles)
         if token
     ]
+
+
+def tokenize_selfies(selfies: str) -> Tokens:
+    """Tokenize SELFIES.
+
+    NOTE: Code adapted from selfies package (`def selfies_to_hot`):
+        https://github.com/aspuru-guzik-group/selfies
+
+    Args:
+        selfies (str): a SELFIES representation (character-level).
+
+    Returns:
+        Tokens: the tokenized SELFIES.
+    """
+
+    selfies = selfies.replace('.', '[.]')  # to allow parsing unbound atoms
+    selfies_char_list_pre = selfies[1:-1].split('][')
+    return [
+        '[' + selfies_element + ']'
+        for selfies_element in selfies_char_list_pre
+    ]

--- a/pytoda/smiles/smiles_language.py
+++ b/pytoda/smiles/smiles_language.py
@@ -18,7 +18,7 @@ class SMILESLanguage(object):
         self,
         name: str = 'smiles-language',
         smiles_tokenizer: SMILESTokenizer = (
-            lambda smiles: tokenize_smiles(smiles, normalize=False)
+            lambda smiles: tokenize_smiles(smiles)
         ),
         add_start_and_stop: bool = False
     ) -> None:
@@ -200,10 +200,10 @@ class SMILESLanguage(object):
         Transform character-level SMILES into a sequence of token indexes.
 
         Args:
-            smiles (str): a SMILES representation.
+            smiles (str): a SMILES (or SELFIES) representation.
 
         Returns:
-            Indexes: indexes representation for the SMILES provided.
+            Indexes: indexes representation for the SMILES/SELFIES provided.
         """
         return self._finalize_token_indexes_fn(
             [

--- a/pytoda/smiles/smiles_language.py
+++ b/pytoda/smiles/smiles_language.py
@@ -197,7 +197,7 @@ class SMILESLanguage(object):
 
     def smiles_to_token_indexes(self, smiles: str) -> Indexes:
         """
-        Transform SMILES into a sequence of token indexes.
+        Transform character-level SMILES into a sequence of token indexes.
 
         Args:
             smiles (str): a SMILES representation.

--- a/pytoda/smiles/tests/test_processing.py
+++ b/pytoda/smiles/tests/test_processing.py
@@ -1,42 +1,55 @@
 """Testing SMILES processing."""
 import unittest
-from pytoda.smiles.processing import (
-    apply_normalization_dictionary, tokenize_smiles
-)
+from pytoda.smiles.processing import tokenize_smiles, tokenize_selfies
+from pytoda.smiles.transforms import Selfies
 
 
 class TestProcessing(unittest.TestCase):
     """Testing processing."""
 
-    def test_apply_normalization_dictionary(self) -> None:
-        """Test apply_normalization_dictionary."""
-        for smiles, ground_truth in [
-            ('c1cnoc1', 'C1CNOC1'),
-            ('[O-][n+]1ccccc1S', '[O-][N+]1CCCCC1S'),
-            ('c1snnc1-c1ccccn1', 'C1SNNC1C1CCCCN1'),
-        ]:
-            self.assertEqual(
-                apply_normalization_dictionary(smiles), ground_truth
-            )
-
     def test_tokenize_smiles(self) -> None:
         """Test tokenize_smiles."""
         for smiles, ground_truth in [
-            ('c1cnoc1', ['C', '1', 'C', 'N', 'O', 'C', '1']),
+            ('c1cnoc1', ['c', '1', 'c', 'n', 'o', 'c', '1']),
             (
                 '[O-][n+]1ccccc1S',
-                ['[O-]', '[N+]', '1', 'C', 'C', 'C', 'C', 'C', '1', 'S']
+                ['[O-]', '[n+]', '1', 'c', 'c', 'c', 'c', 'c', '1', 'S']
             ),
             (
                 'c1snnc1-c1ccccn1', [
-                    'C', '1', 'S', 'N', 'N', 'C', '1', 'C', '1', 'C', 'C', 'C',
-                    'C', 'N', '1'
+                    'c', '1', 's', 'n', 'n', 'c', '1', '-', 'c', '1', 'c', 'c',
+                    'c', 'c', 'n', '1'
                 ]
             )
         ]:
             self.assertListEqual(
-                tokenize_smiles(smiles, normalize=True), ground_truth
+                tokenize_smiles(smiles, normalize=False), ground_truth
             )
+
+    def test_tokenize_selfies(self) -> None:
+        """Test tokenize_selfies."""
+        for smiles, ground_truth in [
+            (
+                'c1cnoc1',
+                ['[c]', '[c]', '[n]', '[o]', '[c]', '[Ring1]', '[Ring2]']
+            ),
+            (
+                '[O-][n+]1ccccc1S', [
+                    '[O-expl]', '[n+expl]', '[c]', '[c]', '[c]', '[c]', '[c]',
+                    '[Ring1]', '[Branch1_1]', '[S]'
+                ]
+            ),
+            (
+                'c1snnc1-c1ccccn1', [
+                    '[c]', '[s]', '[n]', '[n]', '[c]', '[Ring1]', '[Ring2]',
+                    '[-c]', '[c]', '[c]', '[c]', '[c]', '[n]', '[Ring1]',
+                    '[Branch1_1]'
+                ]
+            )
+        ]:
+            transform = Selfies()
+            selfies = transform(smiles)
+            self.assertListEqual(tokenize_selfies(selfies), ground_truth)
 
 
 if __name__ == '__main__':

--- a/pytoda/smiles/tests/test_processing.py
+++ b/pytoda/smiles/tests/test_processing.py
@@ -1,8 +1,9 @@
 """Testing SMILES processing."""
 import unittest
 from pytoda.smiles.processing import (
-    apply_normalization_dictionary, tokenize_smiles
+    apply_normalization_dictionary, tokenize_smiles, tokenize_selfies
 )
+from pytoda.smiles.transforms import Selfies
 
 
 class TestProcessing(unittest.TestCase):
@@ -37,6 +38,31 @@ class TestProcessing(unittest.TestCase):
             self.assertListEqual(
                 tokenize_smiles(smiles, normalize=True), ground_truth
             )
+
+    def test_tokenize_selfies(self) -> None:
+        """Test tokenize_selfies."""
+        for smiles, ground_truth in [
+            (
+                'c1cnoc1',
+                ['[c]', '[c]', '[n]', '[o]', '[c]', '[Ring1]', '[Ring2]']
+            ),
+            (
+                '[O-][n+]1ccccc1S', [
+                    '[O-expl]', '[n+expl]', '[c]', '[c]', '[c]', '[c]', '[c]',
+                    '[Ring1]', '[Branch1_1]', '[S]'
+                ]
+            ),
+            (
+                'c1snnc1-c1ccccn1', [
+                    '[c]', '[s]', '[n]', '[n]', '[c]', '[Ring1]', '[Ring2]',
+                    '[-c]', '[c]', '[c]', '[c]', '[c]', '[n]', '[Ring1]',
+                    '[Branch1_1]'
+                ]
+            )
+        ]:
+            transform = Selfies()
+            selfies = transform(smiles)
+            self.assertListEqual(tokenize_selfies(selfies), ground_truth)
 
 
 if __name__ == '__main__':

--- a/pytoda/smiles/tests/test_processing.py
+++ b/pytoda/smiles/tests/test_processing.py
@@ -51,31 +51,6 @@ class TestProcessing(unittest.TestCase):
             selfies = transform(smiles)
             self.assertListEqual(tokenize_selfies(selfies), ground_truth)
 
-    def test_tokenize_selfies(self) -> None:
-        """Test tokenize_selfies."""
-        for smiles, ground_truth in [
-            (
-                'c1cnoc1',
-                ['[c]', '[c]', '[n]', '[o]', '[c]', '[Ring1]', '[Ring2]']
-            ),
-            (
-                '[O-][n+]1ccccc1S', [
-                    '[O-expl]', '[n+expl]', '[c]', '[c]', '[c]', '[c]', '[c]',
-                    '[Ring1]', '[Branch1_1]', '[S]'
-                ]
-            ),
-            (
-                'c1snnc1-c1ccccn1', [
-                    '[c]', '[s]', '[n]', '[n]', '[c]', '[Ring1]', '[Ring2]',
-                    '[-c]', '[c]', '[c]', '[c]', '[c]', '[n]', '[Ring1]',
-                    '[Branch1_1]'
-                ]
-            )
-        ]:
-            transform = Selfies()
-            selfies = transform(smiles)
-            self.assertListEqual(tokenize_selfies(selfies), ground_truth)
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/pytoda/smiles/tests/test_smiles_language.py
+++ b/pytoda/smiles/tests/test_smiles_language.py
@@ -25,7 +25,7 @@ class TestSmilesLanguage(unittest.TestCase):
         smiles = 'CCO'
         smiles_language = SMILESLanguage()
         smiles_language._update_language_dictionaries_with_tokens(
-            smiles_language.smiles_tokenizer(smiles)
+            smiles_language.tokenizer(smiles)
         )
         self.assertTrue(
             'C' in smiles_language.token_to_index

--- a/pytoda/smiles/tests/test_smiles_language.py
+++ b/pytoda/smiles/tests/test_smiles_language.py
@@ -3,6 +3,8 @@ import unittest
 import os
 from pytoda.smiles.smiles_language import SMILESLanguage
 from pytoda.tests.utils import TestFileContent
+from pytoda.smiles.processing import tokenize_selfies
+from pytoda.smiles.transforms import Selfies
 
 
 class TestSmilesLanguage(unittest.TestCase):
@@ -25,7 +27,7 @@ class TestSmilesLanguage(unittest.TestCase):
         smiles = 'CCO'
         smiles_language = SMILESLanguage()
         smiles_language._update_language_dictionaries_with_tokens(
-            smiles_language.tokenizer(smiles)
+            smiles_language.smiles_tokenizer(smiles)
         )
         self.assertTrue(
             'C' in smiles_language.token_to_index
@@ -95,6 +97,31 @@ class TestSmilesLanguage(unittest.TestCase):
         smiles_language.add_smiles(smiles)
         self.assertListEqual(
             smiles_language.smiles_to_token_indexes(smiles),
+            [smiles_language.start_index] + token_indexes +
+            [smiles_language.stop_index]
+        )
+
+        # SELFIES
+        smiles_language = SMILESLanguage(
+            smiles_tokenizer=lambda selfies: tokenize_selfies(selfies)
+        )
+        transform = Selfies()
+        selfies = transform(smiles)
+        smiles_language.add_smiles(selfies)
+        token_indexes = [
+            smiles_language.token_to_index[token]
+            for token in ['[C]', '[C]', '[O]']
+        ]
+        self.assertListEqual(
+            smiles_language.smiles_to_token_indexes(selfies), token_indexes
+        )
+        smiles_language = SMILESLanguage(
+            add_start_and_stop=True,
+            smiles_tokenizer=lambda selfies: tokenize_selfies(selfies)
+        )
+        smiles_language.add_smiles(selfies)
+        self.assertListEqual(
+            smiles_language.smiles_to_token_indexes(selfies),
             [smiles_language.start_index] + token_indexes +
             [smiles_language.stop_index]
         )

--- a/pytoda/smiles/tests/test_transforms.py
+++ b/pytoda/smiles/tests/test_transforms.py
@@ -1,0 +1,67 @@
+"""Testing SMILES transforms."""
+import unittest
+from pytoda.smiles.transforms import RemoveIsomery, Kekulize
+from pytoda.smiles.transforms import Selfies
+
+
+class TestTransforms(unittest.TestCase):
+    """Testing transforms."""
+
+    def test_kekulize(self) -> None:
+        """Test Kekulize."""
+        for smiles, ground_truth in [
+            ('c1cnoc1', 'C1=CON=C1'),
+            ('[O-][n+]1ccccc1S', '[O-][N+]1=CC=CC=C1S'),
+            ('c1snnc1-c1ccccn1', 'C1=CC=C(C2=CSN=N2)N=C1')
+        ]:
+            transform = Kekulize(allBondsExplicit=False, allHsExplicit=False)
+            self.assertEqual(transform(smiles), ground_truth)
+
+        for smiles, ground_truth in [
+            ('c1cnoc1', 'C1=C-O-N=C-1'),
+            ('[O-][n+]1ccccc1S', '[O-]-[N+]1=C-C=C-C=C-1-S'),
+            ('c1snnc1-c1ccccn1', 'C1=C-C=C(-C2=C-S-N=N-2)-N=C-1')
+        ]:
+            transform = Kekulize(allBondsExplicit=True, allHsExplicit=False)
+            self.assertEqual(transform(smiles), ground_truth)
+
+        for smiles, ground_truth in [
+            ('c1cnoc1', '[CH]1=[CH][O][N]=[CH]1'),
+            ('[O-][n+]1ccccc1S', '[O-][N+]1=[CH][CH]=[CH][CH]=[C]1[SH]'),
+            (
+                'c1snnc1-c1ccccn1',
+                '[CH]1=[CH][CH]=[C]([C]2=[CH][S][N]=[N]2)[N]=[CH]1'
+            )
+        ]:
+            transform = Kekulize(allBondsExplicit=False, allHsExplicit=True)
+            self.assertEqual(transform(smiles), ground_truth)
+
+        for smiles, ground_truth in [
+            ('c1cnoc1', '[CH]1=[CH]-[O]-[N]=[CH]-1'),
+            ('[O-][n+]1ccccc1S', '[O-]-[N+]1=[CH]-[CH]=[CH]-[CH]=[C]-1-[SH]'),
+            (
+                'c1snnc1-c1ccccn1',
+                '[CH]1=[CH]-[CH]=[C](-[C]2=[CH]-[S]-[N]=[N]-2)-[N]=[CH]-1'
+            )
+        ]:
+            transform = Kekulize(allBondsExplicit=True, allHsExplicit=True)
+            self.assertEqual(transform(smiles), ground_truth)
+
+    def test_remove_isomery(self) -> None:
+        """Test RemoveIsomery."""
+
+        for bonddir, chirality, smiles, ground_truth in zip(
+            [False, False, True, True],
+            [False, True, False, True],
+            4 * ['C/C=C/C[C@H](O)Cc1ccccc1'],
+            [
+                'C/C=C/C[C@H](O)Cc1ccccc1', 'C/C=C/CC(O)Cc1ccccc1',
+                'CC=CC[C@H](O)Cc1ccccc1', 'CC=CCC(O)Cc1ccccc1'
+            ]
+        ):  # yapf: disable
+            transform = RemoveIsomery(bonddir=bonddir, chirality=chirality)
+            self.assertEqual(transform(smiles), ground_truth)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/pytoda/smiles/transforms.py
+++ b/pytoda/smiles/transforms.py
@@ -111,8 +111,8 @@ class RemoveIsomery(Transform):
 
         self.chirality_dict = {'[': '', ']': '', '@': '', 'H': ''}
         self.bond_dict = {'/': '', '\\': ''}
-        self.charge = re.compile(r'\[\w+[\+\-]\d?\]')
-        self.multichar_atom = re.compile(r'\[[A-Z][a-z]\w?[0-9]?\]')
+        self.charge = re.compile(r'\[\w+\@?\@?[\+\-]\d?\]')
+        self.multichar_atom = re.compile(r'\[[0-9]?[A-Za-z][a-z]?\w?[2-8]?\]')
         self.bonddir = bonddir
         self.chirality = chirality
 
@@ -146,7 +146,7 @@ class RemoveIsomery(Transform):
             str: SMILES representation of original smiles string with removed
                 stereoinfo checked for validity
         """
-
+        smiles = smiles.replace('[nH]', 'N')
         protect = []
         for m in self.charge.finditer(smiles):
             list_charg = list(range(m.start(), m.end()))
@@ -157,11 +157,11 @@ class RemoveIsomery(Transform):
             protect += list_mc
 
         new_str = []
-        smiles = smiles.replace('[nH]', 'N')
         for index, i in enumerate(smiles):
             new = i.translate(self.updates) if index not in protect else i
             new_str += list(new)
-        smiles = ''.join(new_str).replace('[n]', '[nH]').replace('[N]', '[NH]')
+        smiles = ''.join(new_str).replace('N@@', 'N').replace('N@', 'N')
+
         try:
             Chem.SanitizeMol(Chem.MolFromSmiles(smiles, sanitize=False))
             return smiles

--- a/pytoda/smiles/transforms.py
+++ b/pytoda/smiles/transforms.py
@@ -119,16 +119,15 @@ class RemoveIsomery(Transform):
         if not self.bonddir and not self.chirality:
             self._call_fn = lambda smiles: smiles
         elif self.bonddir and not self.chirality:
-            self.update_dict = self.bond_dict
+            self.updates = str.maketrans(self.bond_dict)
             self._call_fn = self._isomery_call_fn
         elif self.chirality and not self.bonddir:
-            self.update_dict = self.chirality_dict
-            self.call_fn = self._isomery_call_fn
+            self.updates = str.maketrans(self.chirality_dict)
+            self._call_fn = self._isomery_call_fn
         else:
             self._call_fn = lambda smiles: Chem.MolToSmiles(
                 Chem.MolFromSmiles(smiles), isomericSmiles=False
             )
-        self.updates = str.maketrans(self.update_dict)
 
     def _isomery_call_fn(self, smiles: str) -> str:
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ pandas==0.25.2
 torch==1.0.1
 diskcache==4.1.0
 dill==0.3.1.1
+selfies>=0.2.4
 

--- a/setup.py
+++ b/setup.py
@@ -24,12 +24,8 @@ setup(
     url='https://github.com/PaccMann/paccmann_datasets',
     license='MIT',
     install_requires=[
-        'numpy',
-        'scikit-learn',
-        'pandas',
-        'torch>=1.0.0',
-        'diskcache',
-        'dill'
+        'numpy', 'scikit-learn', 'pandas', 'torch>=1.0.0', 'diskcache', 'dill',
+        'selfies'
     ],
     classifiers=[
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ scripts = []
 
 setup(
     name='pytoda',
-    version='0.0.1',
+    version='0.0.2',
     description='pytoda: PaccMann PyTorch Dataset Classes.',
     long_description=LONG_DESCRIPTION,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Major update of supported functionality for SMILES data. Pull request includes a proposal to tag the merged master as v0.0.2 as opposed to the current version (v0.0.1).

New functionalities include:
-  `smiles_dataset` objects now allow to compose various SMILES transformations. The logical order of the supported transformations is as follows (O denotes optional transformations):

    Input SMILES -> `RemoveIsomery` (O) -> `Kekulize` (O) -> `Augment` (O) -> `SELFIES` (O) -> `SMILESToTokenIndexes` -> `Randomize` (O) -> `LeftPadding` (O) -> `ToTensor`

    The new transformations are:
    -  `Kekulize`: discards explicit representation of aromatic structures
        - when `Kekulize` is active, bonds and hydrogen atoms can be made explicit through `allBondsExplicit` and `allHsExplicit`
    - `RemoveIsomery`: removes stereochemistry information of a molecule.
        - when active, removal of direction of bonds and chirality can be controlled independently via `bonddir` and `chirality`.
    - `Selfies` converts a SMILES into a SELFIES string.
    - `Randomize`: implements a true randomization of SMILES tokens (SMILES will be invalid afterwards). This is in contrast to `Augment` which performs an alternative graph traverse to find a valid SMILES sequence (as proposed by Bjerrum). `Augment` is the new name, `SMILESRandomization` is outdated to avoid conflicts.
- since some of these transformations may induce new SMILES characters, `_setup_dataset` as complemented with one swipe over the composed dataset in order to add unknown tokens to the smiles_language object
- `selfies`: 
    - was added as a dependency
    - works smoothly in the entire transformation pipeline (if `selfies=True` is given to `smiles_dataset`, we will use SELFIES instead of SMILES 
    - SELFIES works smoothly in conjunction with `Augment`.
    - No separate "SELFIESLanguage" class was created, instead, simply another tokenizer (`selfies_tokenizer`) is used
- the `SMILES_NORMALIZATION_DICTIONARY ` was removed since it can change the molecular entity. the `normalization` argument of `tokenize_smiles` is kept to ensure backwards compatibility (it has no effect atm and will be removed in a future release, note added in code).
- unittests were added for the new functionalities (`test_processing`, `test_transforms`)