### PR TITLE
Smiles language fix

### DIFF
--- a/examples/smiles_language_creator.py
+++ b/examples/smiles_language_creator.py
@@ -6,7 +6,9 @@ from pytoda.smiles.smiles_language import SMILESLanguage
 
 # define the parser arguments
 parser = argparse.ArgumentParser()
-parser.add_argument('smi_path', type=str, help='path to a input .smi file')
+parser.add_argument(
+    'smi_path', type=str, help='path to a folder with .smi files'
+)
 parser.add_argument(
     'output_filepath', type=str, help='path to a output .csv file'
 )

--- a/pytoda/datasets/_smiles_dataset.py
+++ b/pytoda/datasets/_smiles_dataset.py
@@ -1,12 +1,13 @@
 """Implementation of _SMILESDataset."""
 import torch
 from torch.utils.data import Dataset
-
-from ..smiles.processing import tokenize_selfies, tokenize_smiles
+from ..smiles.processing import (
+    tokenize_selfies, tokenize_smiles, SMILES_TOKENIZER
+)
 from ..smiles.smiles_language import SMILESLanguage
 from ..smiles.transforms import (
-    Augment, Kekulize, NotKekulize, LeftPadding, Randomize, RemoveIsomery, Selfies,
-    SMILESToTokenIndexes, ToTensor, Canonicalization 
+    Augment, Kekulize, NotKekulize, LeftPadding, Randomize, RemoveIsomery,
+    Selfies, SMILESToTokenIndexes, ToTensor, Canonicalization
 )
 from ..transforms import Compose
 from ..types import FileList
@@ -81,7 +82,7 @@ class _SMILESDataset(Dataset):
                 name='selfies-language' if selfies else 'smiles_language',
                 smiles_tokenizer=(
                     (lambda selfies: tokenize_selfies(selfies)) if selfies else
-                    (lambda smiles: tokenize_smiles(smiles))
+                    (lambda smiles: tokenize_smiles(smiles, SMILES_TOKENIZER))
                 ),
                 add_start_and_stop=add_start_and_stop
             )
@@ -101,7 +102,7 @@ class _SMILESDataset(Dataset):
             if padding_length is None else padding_length
         )
         self.kekulize = kekulize
-        self.canonical = canonical 
+        self.canonical = canonical
         self.all_bonds_explicit = all_bonds_explicit
         self.all_hs_explicit = all_hs_explicit
         self.randomize = randomize
@@ -113,9 +114,9 @@ class _SMILESDataset(Dataset):
         # Build up cascade of SMILES transformations
         # Below transformations are optional
         _transforms = []
-        if self.canonical: 
+        if self.canonical:
             _transforms += [Canonicalization()]
-        else: 
+        else:
             if self.remove_bonddir or self.remove_chirality:
                 _transforms += [
                     RemoveIsomery(

--- a/pytoda/smiles/processing.py
+++ b/pytoda/smiles/processing.py
@@ -11,21 +11,22 @@ SMILES_TOKENIZER = re.compile(
 SMILES_NORMALIZER = re.compile(r'-(\w)')
 
 
-def tokenize_smiles(smiles: str, normalize=False) -> Tokens:
+def tokenize_smiles(smiles: str, normalize=False, regexp=None) -> Tokens:
     """
     Tokenize a character-level SMILES string.
 
     Args:
         smiles (str): a SMILES representation.
         normalize (bool): whether normalization is done.
-        
-        NOTE: The `normalize` argument is deprecated and will be removed in a
-        future release.
-
+            NOTE: This argument is deprecated and will be removed in a future
+            release.
+        regexp (None, re.Pattern): optionally pass a regexp for the
+            tokenization. If none is passed, SMILES_TOKENIZER is used.
     Returns:
         Tokens: the tokenized SMILES.
     """
-    return [token for token in SMILES_TOKENIZER.split(smiles) if token]
+    smiles_tokenizer = SMILES_TOKENIZER if regexp is None else regexp
+    return [token for token in smiles_tokenizer.split(smiles) if token]
 
 
 def tokenize_selfies(selfies: str) -> Tokens:

--- a/pytoda/smiles/smiles_language.py
+++ b/pytoda/smiles/smiles_language.py
@@ -3,7 +3,7 @@ import dill
 from collections import Counter
 from ..files import read_smi
 from ..types import FileList, Indexes, SMILESTokenizer, Tokens
-from .processing import tokenize_smiles
+from .processing import tokenize_smiles, SMILES_TOKENIZER
 
 
 class SMILESLanguage(object):
@@ -65,6 +65,7 @@ class SMILESLanguage(object):
             for index, token in additional_indexes_to_token.items()
         }
         self.add_start_and_stop = add_start_and_stop
+        self.smiles_tokenizer_expression = SMILES_TOKENIZER
         if self.add_start_and_stop:
             self.max_token_sequence_length = 2
             self._get_total_number_of_tokens_fn = (

--- a/pytoda/smiles/smiles_language.py
+++ b/pytoda/smiles/smiles_language.py
@@ -65,7 +65,7 @@ class SMILESLanguage(object):
             for index, token in additional_indexes_to_token.items()
         }
         self.add_start_and_stop = add_start_and_stop
-        self.smiles_tokenizer_expression = SMILES_TOKENIZER
+        self._smiles_tokenizer_regexp = SMILES_TOKENIZER
         if self.add_start_and_stop:
             self.max_token_sequence_length = 2
             self._get_total_number_of_tokens_fn = (

--- a/pytoda/smiles/smiles_language.py
+++ b/pytoda/smiles/smiles_language.py
@@ -18,7 +18,7 @@ class SMILESLanguage(object):
         self,
         name: str = 'smiles-language',
         smiles_tokenizer: SMILESTokenizer = (
-            lambda smiles: tokenize_smiles(smiles)
+            lambda smiles: tokenize_smiles(smiles, regexp=SMILES_TOKENIZER)
         ),
         add_start_and_stop: bool = False
     ) -> None:


### PR DESCRIPTION
I attached the regexp to tokenize the SMILES to the smiles language object. I think any SMILES language object should natively have an attribute pointing to the regexp for tokenization. 

The problem with the current code is that if we would change the tokenizer, this may induce inconsistencies in old smiles language objects since they would use the new tokenizer for tokenization although the old tokenizer was used to create the objects. Hence the dictionary may be wrong etc.

Now the default is to use the regexp of the smiles language object for tokenization.