### PR TITLE
Augment transform

### DIFF
--- a/pytoda/smiles/tests/test_transforms.py
+++ b/pytoda/smiles/tests/test_transforms.py
@@ -124,6 +124,8 @@ class TestTransforms(unittest.TestCase):
     def test_augment_tensor(self) -> None:
         """Test AugmentTensor."""
 
+        print(torch.__version__)
+
         smiles = 'NCCS'
         smiles_language = SMILESLanguage(add_start_and_stop=True)
         smiles_language.add_smiles(smiles)
@@ -148,6 +150,8 @@ class TestTransforms(unittest.TestCase):
         seq_len = single_smiles_tensor.shape[1]  # sequence_length
         multi_smiles_tensor = torch.cat([single_smiles_tensor] * 5)
         np.random.seed(0)
+        print(multi_smiles_tensor.shape)
+        print(type(multi_smiles_tensor))
         augmented = transform(multi_smiles_tensor)
 
         for ind, augmented_smile in enumerate(

--- a/pytoda/smiles/tests/test_transforms.py
+++ b/pytoda/smiles/tests/test_transforms.py
@@ -124,8 +124,6 @@ class TestTransforms(unittest.TestCase):
     def test_augment_tensor(self) -> None:
         """Test AugmentTensor."""
 
-        print(torch.__version__)
-
         smiles = 'NCCS'
         smiles_language = SMILESLanguage(add_start_and_stop=True)
         smiles_language.add_smiles(smiles)
@@ -150,8 +148,6 @@ class TestTransforms(unittest.TestCase):
         seq_len = single_smiles_tensor.shape[1]  # sequence_length
         multi_smiles_tensor = torch.cat([single_smiles_tensor] * 5)
         np.random.seed(0)
-        print(multi_smiles_tensor.shape)
-        print(type(multi_smiles_tensor))
         augmented = transform(multi_smiles_tensor)
 
         for ind, augmented_smile in enumerate(

--- a/pytoda/smiles/transforms.py
+++ b/pytoda/smiles/transforms.py
@@ -370,12 +370,12 @@ class AugmentTensor(Transform):
             padding = True
 
             left_padding = any([
-                self.smiles_language.padding_index in t[0]
-                for t in smiles_numerical
+                self.smiles_language.padding_index in smiles_numerical[ind, 0]
+                for ind in range(smiles_numerical.shape[0])
             ])  # yapf: disable
             right_padding = any([
-                self.smiles_language.padding_index in t[-1]
-                for t in smiles_numerical
+                self.smiles_language.padding_index in smiles_numerical[ind, -1]
+                for ind in range(smiles_numerical.shape[0])
             ])  # yapf: disable
             if (
                 (left_padding and right_padding)

--- a/pytoda/smiles/transforms.py
+++ b/pytoda/smiles/transforms.py
@@ -317,11 +317,11 @@ class AugmentTensor(Transform):
         Apply the transform.
 
         Args:
-            smiles_numerical (list, torch.Tensor): either a SMILES represented
-            as list of ints or a Tensor.
+            smiles_numerical (Union[list, torch.Tensor]): either a SMILES
+                represented as list of ints or a Tensor.
 
         Returns:
-            str: randomized SMILES representation.
+            torch.Tensor: randomized SMILES representation.
         """
 
         if type(smiles_numerical) == list:
@@ -368,14 +368,13 @@ class AugmentTensor(Transform):
         if self.smiles_language.padding_index in smiles_numerical.flatten():
 
             padding = True
-
             left_padding = any([
-                self.smiles_language.padding_index in smiles_numerical[ind, 0]
-                for ind in range(smiles_numerical.shape[0])
+                self.smiles_language.padding_index == row[0]
+                for row in smiles_numerical
             ])  # yapf: disable
             right_padding = any([
-                self.smiles_language.padding_index in smiles_numerical[ind, -1]
-                for ind in range(smiles_numerical.shape[0])
+                self.smiles_language.padding_index == row[-1]
+                for row in smiles_numerical
             ])  # yapf: disable
             if (
                 (left_padding and right_padding)

--- a/pytoda/smiles/transforms.py
+++ b/pytoda/smiles/transforms.py
@@ -317,29 +317,104 @@ class AugmentTensor(Transform):
         Apply the transform.
 
         Args:
-            smiles_numerical (list): a SMILES represented as list of ints
+            smiles_numerical (list, torch.Tensor): either a SMILES represented
+            as list of ints or a Tensor.
 
         Returns:
             str: randomized SMILES representation.
         """
-        smiles = self.smiles_language.token_indexes_to_smiles(smiles_numerical)
-        molecule = Chem.MolFromSmiles(smiles)
-        atom_indexes = list(range(molecule.GetNumAtoms()))
-        if len(atom_indexes) == 0:  # RDkit error handling
-            return smiles
-        np.random.shuffle(atom_indexes)
-        renumbered_molecule = Chem.RenumberAtoms(molecule, atom_indexes)
-        if self.kekule_smiles:
-            Chem.Kekulize(renumbered_molecule)
 
-        augmented_smiles = Chem.MolToSmiles(
-            renumbered_molecule,
-            canonical=False,
-            kekuleSmiles=self.kekule_smiles,
-            allBondsExplicit=self.all_bonds_explicit,
-            allHsExplicit=self.all_hs_explicit
-        )
-        return self.smiles_language.smiles_to_token_indexes(augmented_smiles)
+        if type(smiles_numerical) == list:
+            smiles = self.smiles_language.token_indexes_to_smiles(
+                smiles_numerical
+            )
+            molecule = Chem.MolFromSmiles(smiles)
+            atom_indexes = list(range(molecule.GetNumAtoms()))
+            if len(atom_indexes) == 0:  # RDkit error handling
+                return smiles
+            np.random.shuffle(atom_indexes)
+            renumbered_molecule = Chem.RenumberAtoms(molecule, atom_indexes)
+            if self.kekule_smiles:
+                Chem.Kekulize(renumbered_molecule)
+
+            augmented_smiles = Chem.MolToSmiles(
+                renumbered_molecule,
+                canonical=False,
+                kekuleSmiles=self.kekule_smiles,
+                allBondsExplicit=self.all_bonds_explicit,
+                allHsExplicit=self.all_hs_explicit
+            )
+            return self.smiles_language.smiles_to_token_indexes(
+                augmented_smiles
+            )
+        elif type(smiles_numerical) == torch.Tensor:
+            return self.__call__tensor(smiles_numerical)
+
+        else:
+            raise TypeError('Please pass either a torch.Tensor or a list.')
+
+    def __call__tensor(self, smiles_numerical: torch.Tensor) -> str:
+        """
+        Wrapper of the transform for torch.Tensor.
+
+        Args:
+            smiles_numerical (torch.Tensor): a Tensor with SMILES represented
+                as ints. Needs to have shape batch_size x sequence_length.
+        Returns:
+            str: randomized SMILES representation.
+        """
+
+        # Infer the padding type to ensure returning tensor of same shape.
+        if self.smiles_language.padding_index in smiles_numerical.flatten():
+
+            padding = True
+
+            left_padding = any([
+                self.smiles_language.padding_index in t[0]
+                for t in smiles_numerical
+            ])  # yapf: disable
+            right_padding = any([
+                self.smiles_language.padding_index in t[-1]
+                for t in smiles_numerical
+            ])  # yapf: disable
+            if (
+                (left_padding and right_padding)
+                or (not left_padding and not right_padding)
+            ):
+                raise ValueError(
+                    'Could not uniqely infer padding type. Leftpadding was '
+                    f'{left_padding}, right_padding was {right_padding}.'
+                )
+        else:
+            padding = False
+
+        seq_len = smiles_numerical.shape[1]
+
+        # Loop over tensor (SMILES by SMILES) and augment. Exclude augmentation
+        # if it violates the padding
+        augmented = []
+        for smiles in smiles_numerical:
+
+            lenx = seq_len + 1
+            while lenx > seq_len:
+                augmented_smiles = self.__call__(smiles.tolist())
+                lenx = len(augmented_smiles)
+            if padding:
+                pads = (
+                    [self.smiles_language.padding_index] *
+                    (seq_len - len(augmented_smiles))
+                )
+                if right_padding:
+                    augmented_smiles = augmented_smiles + pads
+                if left_padding:
+                    augmented_smiles = pads + augmented_smiles
+
+            augmented.append(
+                torch.unsqueeze(torch.Tensor(augmented_smiles), 0)
+            )
+
+        augmented = torch.cat(augmented, dim=0)
+        return augmented
 
 
 class Randomize(Transform):


### PR DESCRIPTION
Including a new transform `AugmentTensor`. Like `Augment` this performs SMILES augmentation, but not on a SMILES string but on a Tensor. This is nice, since it obviates the need of carrying a `SMILESDataset` object along, e.g. in case of using a deployed model on a lightweight backend.

The AugmentTensor can be called with either a list of ints representing the SMILES tokens or with a 2D Tensor, one numerical SMILES vector per row. In the latter case, the padding type (left padding vs. right padding) is inferred dynamically. I also ensure that the augmentation does not result in a sequence that is longer than the tensor itself (e.g. having 'CCO' as longestSMILES in the batch and having it augmented to `C(C)O` would result in a tensor mistmatch).

I also added the unittest.

