### PR TITLE
fix: fixes #9 (squeezing shape of SMILES_dataset.__getitem__)

### DIFF
--- a/pytoda/datasets/tests/test_drug_sensitivity_eager_dataset.py
+++ b/pytoda/datasets/tests/test_drug_sensitivity_eager_dataset.py
@@ -111,10 +111,7 @@ class TestDrugSensitivityDataset(unittest.TestCase):
                     np.testing.assert_almost_equal(
                         token_indexes_tensor.numpy(),
                         np.array(
-                            [
-                                [padding_index], [padding_index], [c_index],
-                                [o_index]
-                            ]
+                            [padding_index, padding_index, c_index, o_index]
                         )
                     )
                     np.testing.assert_almost_equal(
@@ -176,7 +173,7 @@ class TestDrugSensitivityDataset(unittest.TestCase):
                             ic50_batch
                         )
                     ) in enumerate(data_loader):
-                        self.assertEqual(token_indexes_batch.size(), (2, 4, 1))
+                        self.assertEqual(token_indexes_batch.size(), (2, 4))
                         self.assertEqual(gene_expression_batch.size(), (2, 4))
                         self.assertEqual(ic50_batch.size(), (2, 1))
                         if batch_index > 4:

--- a/pytoda/datasets/tests/test_drug_sensitivity_lazy_dataset.py
+++ b/pytoda/datasets/tests/test_drug_sensitivity_lazy_dataset.py
@@ -111,10 +111,7 @@ class TestDrugSensitivityDataset(unittest.TestCase):
                     np.testing.assert_almost_equal(
                         token_indexes_tensor.numpy(),
                         np.array(
-                            [
-                                [padding_index], [padding_index], [c_index],
-                                [o_index]
-                            ]
+                            [padding_index, padding_index, c_index, o_index]
                         )
                     )
                     np.testing.assert_almost_equal(
@@ -176,7 +173,7 @@ class TestDrugSensitivityDataset(unittest.TestCase):
                             ic50_batch
                         )
                     ) in enumerate(data_loader):
-                        self.assertEqual(token_indexes_batch.size(), (2, 4, 1))
+                        self.assertEqual(token_indexes_batch.size(), (2, 4))
                         self.assertEqual(gene_expression_batch.size(), (2, 4))
                         self.assertEqual(ic50_batch.size(), (2, 1))
                         if batch_index > 4:

--- a/pytoda/datasets/tests/test_smiles_eager_dataset.py
+++ b/pytoda/datasets/tests/test_smiles_eager_dataset.py
@@ -169,7 +169,7 @@ class TestSMILESDatasetEagerBackend(unittest.TestCase):
                     smiles_dataset, batch_size=4, shuffle=True
                 )
                 for batch_index, batch in enumerate(data_loader):
-                    self.assertEqual(batch.shape, (4, 4, 1))
+                    self.assertEqual(batch.shape, (4, 4))
                     if batch_index > 10:
                         break
 

--- a/pytoda/datasets/tests/test_smiles_lazy_dataset.py
+++ b/pytoda/datasets/tests/test_smiles_lazy_dataset.py
@@ -169,7 +169,7 @@ class TestSMILESDatasetLazyBackend(unittest.TestCase):
                     smiles_dataset, batch_size=4, shuffle=True
                 )
                 for batch_index, batch in enumerate(data_loader):
-                    self.assertEqual(batch.shape, (4, 4, 1))
+                    self.assertEqual(batch.shape, (4, 4))
                     if batch_index > 10:
                         break
 

--- a/pytoda/smiles/transforms.py
+++ b/pytoda/smiles/transforms.py
@@ -95,7 +95,7 @@ class ToTensor(Transform):
         """
         return torch.tensor(
             token_indexes, dtype=self.dtype, device=self.device
-        ).view(-1, 1)
+        ).view(-1, 1).squeeze()
 
 
 class RemoveIsomery(Transform):


### PR DESCRIPTION
Wrapping the `.view(-1,1)` in `ToTensor` into a `.squeeze()` in order to prevent having an additional dimension in the output tensor (`bs x sequence_length x 1`) which can cause downstream errors in the model.
Had to adapt the unittests.