### PR TITLE
Preprocessing

### DIFF
--- a/pytoda/data_splitter.py
+++ b/pytoda/data_splitter.py
@@ -20,13 +20,13 @@ def csv_data_splitter(
     **kwargs
 ) -> Tuple[str, str]:
     """
-    Function for generic splitting into train and test data in csv format..
+    Function for generic splitting into train and test data in csv format.
     This is an eager splitter trying to fit the entire dataset into memory.
 
     Args:
         data_filepaths (FileList): a list of .csv files that contain the data.
         save_path (str): folder to store the training/testing dataset.
-        data_type (str): data type.
+        data_type (str): data type (only used as prefix for the saved files).
         mode (str): mode to split data from: "random" and "file".
             - random: does a random split across all samples in all files.
             - file: randomly splits the files into training and testing.
@@ -106,7 +106,7 @@ def csv_data_splitter(
         _hash_from_df_columns(test_df, number_of_columns)
     )
     hash_fn.update(hash_str.encode('utf-8'))
-    hash_id = str(int(hash_fn.hexdigest(), 16))
+    hash_id = str(int(hash_fn.hexdigest(), 16))[:6]
     # generate file path
     train_filepath = os.path.join(
         save_path,

--- a/pytoda/datasets/_smiles_dataset.py
+++ b/pytoda/datasets/_smiles_dataset.py
@@ -53,8 +53,9 @@ class _SMILESDataset(Dataset):
                 applies only if padding is True. Defaults to None.
             add_start_and_stop (bool): add start and stop token indexes.
                 Defaults to False.
-            canonical (bool): performs canonicalization of SMILES (one original string for one molecule),
-                if canonical=True, then other transformations (augment etc, see below) do not apply
+            canonical (bool): performs canonicalization of SMILES (one original
+                string for one molecule). If True, then other transformations
+                (augment etc, see below) do not apply.
             augment (bool): perform SMILES augmentation. Defaults to False.
             kekulize (bool): kekulizes SMILES (implicit aromaticity only).
                 Defaults to False.
@@ -164,7 +165,9 @@ class _SMILESDataset(Dataset):
             transforms += [Randomize()]
         if self.padding:
             if padding_length is None:
-                self.padding_length = self.smiles_language.max_token_sequence_length
+                self.padding_length = (
+                    self.smiles_language.max_token_sequence_length
+                )
             transforms += [
                 LeftPadding(
                     padding_length=self.padding_length,
@@ -177,10 +180,14 @@ class _SMILESDataset(Dataset):
         # NOTE: recover sample and index mappings
         self.sample_to_index_mapping = {}
         self.index_to_sample_mapping = {}
+
         for index in range(len(self._dataset)):
             dataset_index, sample_index = self._dataset.get_index_pair(index)
             dataset = self._dataset.datasets[dataset_index]
-            sample = dataset.index_to_sample_mapping[sample_index]
+            try:
+                sample = dataset.index_to_sample_mapping[sample_index]
+            except KeyError:
+                raise KeyError('Please remove duplicates from your .smi file.')
             self.sample_to_index_mapping[sample] = index
             self.index_to_sample_mapping[index] = sample
 

--- a/pytoda/datasets/_table_dataset.py
+++ b/pytoda/datasets/_table_dataset.py
@@ -108,8 +108,8 @@ class _TableDataset(Dataset):
             self.processing = {
                 'processing': 'standardize',
                 'parameters': {
-                    'mean': mean,
-                    'std': std
+                    'mean': list(mean),
+                    'std': list(std)
                 }
             }
         elif self.min_max:

--- a/pytoda/datasets/_table_eager_dataset.py
+++ b/pytoda/datasets/_table_eager_dataset.py
@@ -58,6 +58,7 @@ class _TableEagerDataset(_TableDataset):
             filepaths=self.filepaths,
             dataset_class=_CsvEagerDataset,
             feature_list=self.feature_list,
+            dtype={'cell_line': str},
             **self.kwargs
         )
 

--- a/pytoda/datasets/smiles_dataset.py
+++ b/pytoda/datasets/smiles_dataset.py
@@ -33,8 +33,9 @@ class SMILESDataset(Dataset):
         remove_bonddir: bool = False,
         remove_chirality: bool = False,
         selfies: bool = False,
-        device: torch.device = torch.
-        device('cuda' if torch.cuda.is_available() else 'cpu'),
+        device: torch.device = (
+            torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+        ),
         backend: str = 'eager'
     ) -> None:
         """
@@ -50,8 +51,9 @@ class SMILESDataset(Dataset):
                 applies only if padding is True. Defaults to None.
             add_start_and_stop (bool): add start and stop token indexes.
                 Defaults to False.
-            canonical (bool): performs canonicalization of SMILES (one original string for one molecule),
-                if canonical=True, then other transformations (augment etc, see below) do not apply
+            canonical (bool): performs canonicalization of SMILES (one
+                original string for one molecule), if True, then other
+                transformations (augment etc, see below) do not apply
             augment (bool): perform SMILES augmentation. Defaults to False.
             kekulize (bool): kekulizes SMILES (implicit aromaticity only).
                 Defaults to False.

--- a/pytoda/preprocessing/combat.py
+++ b/pytoda/preprocessing/combat.py
@@ -1,0 +1,242 @@
+"""
+This is the implementation of COMBAT, a method to adjust for batch effects in
+microarray data that uses bayesian techniques.
+
+It was developed to deal with small data batches (< 25) but shows comparable
+performance to other techniques for large batches.
+
+The code was retrieved from https://github.com/brentp/combat.py at 22.02.2020
+    Git commit ID: 5ac2e89
+
+Reference:
+    Johnson WE, Rabinovic A, Li C (2007). Adjusting batch effects in microarray
+    expression data using Empirical Bayes methods. Biostatistics 8:118-127.  
+    https://academic.oup.com/biostatistics/article/8/1/118/252073 
+"""
+
+import pandas as pd
+import patsy
+import sys
+import numpy.linalg as la
+import numpy as np
+
+
+def adjust_nums(numerical_covariates, drop_idxs):
+    # if we dropped some values, have to adjust those with a larger index.
+    if numerical_covariates is None:
+        return drop_idxs
+    return [
+        nc - sum(nc < di for di in drop_idxs) for nc in numerical_covariates
+    ]
+
+
+def design_mat(mod, numerical_covariates, batch_levels):
+    # require levels to make sure they are in the same order as we use in the
+    # rest of the script.
+    design = patsy.dmatrix(
+        "~ 0 + C(batch, levels=%s)" % str(batch_levels),
+        mod,
+        return_type="dataframe"
+    )
+
+    mod = mod.drop(["batch"], axis=1)
+    numerical_covariates = list(numerical_covariates)
+    sys.stderr.write("found %i batches\n" % design.shape[1])
+    other_cols = [
+        c for i, c in enumerate(mod.columns) if not i in numerical_covariates
+    ]
+    factor_matrix = mod[other_cols]
+    design = pd.concat((design, factor_matrix), axis=1)
+    if numerical_covariates is not None:
+        sys.stderr.write(
+            "found %i numerical covariates...\n" % len(numerical_covariates)
+        )
+        for i, nC in enumerate(numerical_covariates):
+            cname = mod.columns[nC]
+            sys.stderr.write("\t{0}\n".format(cname))
+            design[cname] = mod[mod.columns[nC]]
+    sys.stderr.write("found %i categorical variables:" % len(other_cols))
+    sys.stderr.write("\t" + ", ".join(other_cols) + '\n')
+    return design
+
+
+def combat(data, batch, model=None, numerical_covariates=None):
+    """Correct for batch effects in a dataset
+    NOTE: Data requires to be (n_features, n_samples)!
+    Parameters
+    ----------
+    data : pandas.DataFrame
+        A (n_features, n_samples) dataframe of the expression or methylation
+        data to batch correct
+    batch : pandas.Series
+        A column corresponding to the batches in the data, with index same as
+        the columns that appear in ``data``
+    model : patsy.design_info.DesignMatrix, optional
+        A model matrix describing metadata on the samples which could be
+        causing batch effects. If not provided, then will attempt to coarsely
+        correct just from the information provided in ``batch``
+    numerical_covariates : list-like
+        List of covariates in the model which are numerical, rather than
+        categorical
+    Returns
+    -------
+    corrected : pandas.DataFrame
+        A (n_features, n_samples) dataframe of the batch-corrected data
+    """
+    if isinstance(numerical_covariates, str):
+        numerical_covariates = [numerical_covariates]
+    if numerical_covariates is None:
+        numerical_covariates = []
+
+    if model is not None and isinstance(model, pd.DataFrame):
+        model["batch"] = list(batch)
+    else:
+        model = pd.DataFrame({'batch': batch})
+
+    batch_items = model.groupby("batch").groups.items()
+    batch_levels = [k for k, v in batch_items]
+    batch_info = [v for k, v in batch_items]
+    n_batch = len(batch_info)
+    n_batches = np.array([len(v) for v in batch_info])
+    n_array = float(sum(n_batches))
+
+    # drop intercept
+    drop_cols = [
+        cname for cname, inter in ((model == 1).all()).iteritems() if inter
+    ]
+    drop_idxs = [list(model.columns).index(cdrop) for cdrop in drop_cols]
+    model = model[[c for c in model.columns if not c in drop_cols]]
+    numerical_covariates = [
+        list(model.columns).index(c) if isinstance(c, str) else c
+        for c in numerical_covariates if not c in drop_cols
+    ]
+
+    design = design_mat(model, numerical_covariates, batch_levels)
+
+    sys.stderr.write("Standardizing Data across genes.\n")
+    B_hat = np.dot(np.dot(la.inv(np.dot(design.T, design)), design.T), data.T)
+    grand_mean = np.dot((n_batches / n_array).T, B_hat[:n_batch, :])
+    var_pooled = np.dot(
+        ((data - np.dot(design, B_hat).T)**2),
+        np.ones((int(n_array), 1)) / int(n_array)
+    )
+
+    stand_mean = np.dot(
+        grand_mean.T.reshape((len(grand_mean), 1)), np.ones((1, int(n_array)))
+    )
+    tmp = np.array(design.copy())
+    tmp[:, :n_batch] = 0
+    stand_mean += np.dot(tmp, B_hat).T
+
+    s_data = (
+        (data - stand_mean) /
+        np.dot(np.sqrt(var_pooled), np.ones((1, int(n_array))))
+    )
+
+    sys.stderr.write("Fitting L/S model and finding priors\n")
+    batch_design = design[design.columns[:n_batch]]
+    gamma_hat = np.dot(
+        np.dot(la.inv(np.dot(batch_design.T, batch_design)), batch_design.T),
+        s_data.T
+    )
+
+    delta_hat = []
+
+    for i, batch_idxs in enumerate(batch_info):
+        #batches = [list(model.columns).index(b) for b in batches]
+        delta_hat.append(s_data[batch_idxs].var(axis=1))
+
+    gamma_bar = gamma_hat.mean(axis=1)
+    t2 = gamma_hat.var(axis=1)
+
+    a_prior = list(map(aprior, delta_hat))
+    b_prior = list(map(bprior, delta_hat))
+
+    sys.stderr.write("Finding parametric adjustments\n")
+    gamma_star, delta_star = [], []
+    for i, batch_idxs in enumerate(batch_info):
+        #print '18 20 22 28 29 31 32 33 35 40 46'
+        #print batch_info[batch_id]
+
+        temp = it_sol(
+            s_data[batch_idxs], gamma_hat[i], delta_hat[i], gamma_bar[i],
+            t2[i], a_prior[i], b_prior[i]
+        )
+
+        gamma_star.append(temp[0])
+        delta_star.append(temp[1])
+
+    sys.stdout.write("Adjusting data\n")
+    bayesdata = s_data
+    gamma_star = np.array(gamma_star)
+    delta_star = np.array(delta_star)
+
+    for j, batch_idxs in enumerate(batch_info):
+
+        dsq = np.sqrt(delta_star[j, :])
+        dsq = dsq.reshape((len(dsq), 1))
+        denom = np.dot(dsq, np.ones((1, n_batches[j])))
+        numer = np.array(
+            bayesdata[batch_idxs] -
+            np.dot(batch_design.loc[batch_idxs], gamma_star).T
+        )
+
+        bayesdata[batch_idxs] = numer / denom
+
+    vpsq = np.sqrt(var_pooled).reshape((len(var_pooled), 1))
+    bayesdata = bayesdata * np.dot(
+        vpsq, np.ones((1, int(n_array)))
+    ) + stand_mean
+
+    return bayesdata
+
+
+def it_sol(sdat, g_hat, d_hat, g_bar, t2, a, b, conv=0.0001):
+    n = (1 - np.isnan(sdat)).sum(axis=1)
+    g_old = g_hat.copy()
+    d_old = d_hat.copy()
+
+    change = 1
+    count = 0
+    while change > conv:
+        #print g_hat.shape, g_bar.shape, t2.shape
+        g_new = postmean(g_hat, g_bar, n, d_old, t2)
+        sum2 = (
+            (
+                sdat - np.dot(
+                    g_new.values.reshape((g_new.shape[0], 1)),
+                    np.ones((1, sdat.shape[1]))
+                )
+            )**2
+        ).sum(axis=1)
+        d_new = postvar(sum2, n, a, b)
+
+        change = max(
+            (abs(g_new - g_old) / g_old).max(),
+            (abs(d_new - d_old) / d_old).max()
+        )
+        g_old = g_new  #.copy()
+        d_old = d_new  #.copy()
+        count = count + 1
+    adjust = (g_new, d_new)
+    return adjust
+
+
+def aprior(gamma_hat):
+    m = gamma_hat.mean()
+    s2 = gamma_hat.var()
+    return (2 * s2 + m**2) / s2
+
+
+def bprior(gamma_hat):
+    m = gamma_hat.mean()
+    s2 = gamma_hat.var()
+    return (m * s2 + m**3) / s2
+
+
+def postmean(g_hat, g_bar, n, d_star, t2):
+    return (t2 * n * g_hat + d_star * g_bar) / (t2 * n + d_star)
+
+
+def postvar(sum2, n, a, b):
+    return (0.5 * sum2 + b) / (n / 2.0 + a - 1.0)

--- a/pytoda/preprocessing/crawlers.py
+++ b/pytoda/preprocessing/crawlers.py
@@ -1,0 +1,115 @@
+import urllib
+import urllib.error as urllib_error
+import urllib.request as urllib_request
+from typing import Union
+
+ZINC_DRUG_SEARCH_ROOT = 'http://zinc.docking.org/substances/search/?q='
+ZINC_ID_SEARCH_ROOT = 'http://zinc.docking.org/substances/'
+
+PUBCHEM_START = 'https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/name/'
+PUBCHEM_MID = '/property/'
+PUBCHEM_END = '/TXT'
+
+
+def get_smiles_from_zinc(drug: Union[str, int]) -> str:
+    """
+    Uses the ZINC databases to retrieve the SMILES of a ZINC ID (int) or a drug
+    name (str). 
+
+    Args:
+        drug (Union[str, int]) -- A string with a drug name or an int of a ZINC
+            ID.
+    Returns:
+        smiles (str) -- The SMILES string of the drug name or ZINC ID.
+    """
+
+    if type(drug) != str and type(drug) != int:
+        raise TypeError(
+            f'Please insert drug of type {{str, int}}, given was {type(drug)}'
+            f'({drug}).'
+        )
+
+    if type(drug) == str:
+
+        # Parse name, then retrieve ZINC ID from it
+        stripped_drug = drug.strip()
+        zinc_ids = []
+        try:
+            drug_url = urllib_request.pathname2url(stripped_drug)
+            path = '{}{}'.format(ZINC_DRUG_SEARCH_ROOT, drug_url)
+            response = urllib.request.urlopen(path)
+
+            for line in response:
+                line = line.decode(encoding='UTF-8').strip()
+                if 'href="/substances/ZINC' in line:
+                    zinc_ids.append(line.split('/')[-2])
+            zinc_id = zinc_ids[0]
+
+        except urllib_error.HTTPError:
+            print(f'Did not find any result for drug: {drug}')
+            return []
+
+    elif type(drug) == int:
+        zinc_id = str(drug)
+
+    zinc_id_url = ZINC_ID_SEARCH_ROOT + zinc_id
+    id_response = urllib_request.urlopen(zinc_id_url)
+
+    for id_line in id_response:
+        id_line = id_line.decode(encoding='UTF-8').strip()
+        if 'id="substance-smiles-field" readonly value=' in id_line:
+            smiles = id_line.split('"')[-2]
+
+    return smiles
+
+
+def get_smiles_from_pubchem(
+    drug: str, use_isomeric: bool = True, kekulize: bool = False
+) -> str:
+    """
+
+    Uses the PubChem database to retrieve the SMILES of a drug name (str). 
+
+    Args:
+        drug (str) -- A string with a drug name (or a PubChem ID as a string).
+        use_isomeric (bool, optional) - If available, returns the isomeric
+            SMILES, not the canonical one.
+        kekulize (bool, optional) -- Whether kekulization is used. PubChem uses
+            kekulization per default, so setting this to 'True' will not
+            perform any operation on the retrieved SMILES. 
+            NOTE: Setting it to 'False' will convert aromatic atoms to lower-
+            case characters and *induces a RDKit dependency*
+    Returns:
+        smiles (str) -- The SMILES string of the drug name.
+    """
+
+    if type(drug) != str:
+        raise TypeError(
+            f'Please insert drug of type str, given was {type(drug)}({drug}).'
+        )
+    if not kekulize:
+        from rdkit import Chem
+
+    options = ['CanonicalSMILES']
+    if use_isomeric:
+        options = ['IsomericSMILES'] + options
+
+    # Parse name
+    stripped_drug = drug.strip()
+
+    # Search ZINC for compound name
+    for option in options:
+        try:
+            path = '{}{}{}{}{}'.format(
+                PUBCHEM_START, stripped_drug, PUBCHEM_MID, option, PUBCHEM_END
+            )
+            smiles = urllib_request.urlopen(path).read(
+            ).decode('UTF-8').replace('\n', '')
+            if not kekulize:
+                smiles = Chem.MolToSmiles(Chem.MolFromSmiles(smiles))
+            return smiles
+        except urllib_error.HTTPError:
+            if option == 'CanonicalSMILES':
+                print(f'Did not find any result for drug: {drug}')
+                return []
+            continue

--- a/pytoda/preprocessing/tests/test_crawlers.py
+++ b/pytoda/preprocessing/tests/test_crawlers.py
@@ -1,0 +1,57 @@
+"""Testing Crawlers."""
+import unittest
+from pytoda.preprocessing.crawlers import (
+    get_smiles_from_zinc, get_smiles_from_pubchem
+)
+
+
+class TestCrawlers(unittest.TestCase):
+    """Testing Crawlsers."""
+
+    def test_get_smiles_from_zinc(self) -> None:
+        """Test get_smiles_from_zinc"""
+
+        # Test text mode
+        drug = 'Aspirin'
+        ground_truth = 'CC(=O)Oc1ccccc1C(=O)O'
+        smiles = get_smiles_from_zinc(drug)
+        self.assertEqual(smiles, ground_truth)
+
+        # Test ZINC ID mode
+        zinc_id = 53
+        ground_truth = 'CC(=O)Oc1ccccc1C(=O)O'
+        smiles = get_smiles_from_zinc(zinc_id)
+        self.assertEqual(smiles, ground_truth)
+
+    def test_get_smiles_from_pubchem(self) -> None:
+        """Test get_smiles_from_zinc"""
+
+        # Test text mode
+        drug = 'isoliquiritigenin'
+        ground_truth = 'C1=CC(=CC=C1/C=C/C(=O)C2=C(C=C(C=C2)O)O)O'
+        smiles = get_smiles_from_pubchem(
+            drug, use_isomeric=True, kekulize=True
+        )
+        self.assertEqual(smiles, ground_truth)
+
+        ground_truth = 'C1=CC(=CC=C1C=CC(=O)C2=C(C=C(C=C2)O)O)O'
+        smiles = get_smiles_from_pubchem(
+            drug, use_isomeric=False, kekulize=True
+        )
+        self.assertEqual(smiles, ground_truth)
+
+        ground_truth = 'O=C(/C=C/c1ccc(O)cc1)c1ccc(O)cc1O'
+        smiles = get_smiles_from_pubchem(
+            drug, use_isomeric=True, kekulize=False
+        )
+        self.assertEqual(smiles, ground_truth)
+
+        ground_truth = 'O=C(C=Cc1ccc(O)cc1)c1ccc(O)cc1O'
+        smiles = get_smiles_from_pubchem(
+            drug, use_isomeric=False, kekulize=False
+        )
+        self.assertEqual(smiles, ground_truth)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Main improvement of this pull request is that I added a submodule `pytoda.preprocessing` that includes two files. 

1.  First, `crawlers.py` which contains `get_smiles_from_zinc` and  `get_smiles_from_pubchem`. These methods are useful to assemble SMILES datasets when only compound names are available. The first method can be used to retrieve a SMILES string from either 1) a string such as a drug name or 2) a ZINC ID which is searched for in the DB. The second method,  `get_smiles_from_pubchem`, retrieves the SMILES from a string that is fed into the PubChem DB. Both methods have unittests implemented.

2. A file called `combat.py` that implements a preprocessing method to adjust for batch effects in
microarray data that uses bayesian techniques. It was developed to deal with small data batches (< 25) but shows comparable performance to other techniques for large batches. The code was retrieved from https://github.com/brentp/combat.py (22.02.2020 Git commit ID: 5ac2e89).
Reference:
    Johnson WE, Rabinovic A, Li C (2007). Adjusting batch effects in microarray
    expression data using Empirical Bayes methods. Biostatistics 8:118-127.  
    https://academic.oup.com/biostatistics/article/8/1/118/252073 


Moreover, I did various minor improvements to `pytoda.datasets` including:
-  error raising when duplicate SMILES are detected (there was an opaque error before) 
- `DrugSensitivityDataset` now passes all options for the smiles language configuration down to `SMILESDataset` (like `remove_chirality=True`)
