### PR TITLE
feat: SMILESLanguage has now SELFIES transformation method

### DIFF
--- a/pytoda/smiles/smiles_language.py
+++ b/pytoda/smiles/smiles_language.py
@@ -4,6 +4,8 @@ from collections import Counter
 from ..files import read_smi
 from ..types import FileList, Indexes, SMILESTokenizer, Tokens
 from .processing import tokenize_smiles, SMILES_TOKENIZER
+from selfies import encoder as selfies_encoder
+from selfies import decoder as selfies_decoder
 
 
 class SMILESLanguage(object):
@@ -251,3 +253,39 @@ class SMILESLanguage(object):
                 if token_index > 3
             ]
         )
+
+    def selfies_to_smiles(self, selfies: str) -> str:
+        """
+        SELFIES to SMILES converter method.
+        Based on: https://arxiv.org/abs/1905.13741
+
+        Arguments:
+            selfies {str} -- SELFIES representation
+
+        Returns:
+            str -- A SMILES string
+        """
+        if not isinstance(selfies, str):
+            raise TypeError(f'Wrong data type: {type(selfies)}. Use strings.')
+        try:
+            return selfies_decoder(selfies)
+        except Exception:
+            print(f'Could not convert selfies {selfies} to SMILES.')
+
+    def smiles_to_selfies(self, smiles: str) -> str:
+        """
+        SMILES to SELFIES converter method.
+        Based on: https://arxiv.org/abs/1905.13741
+
+        Arguments:
+            smiles {str} -- smiles representation
+
+        Returns:
+            str -- A SELFIES string
+        """
+        if not isinstance(smiles, str):
+            raise TypeError(f'Wrong data type: {type(smiles)}. Use strings.')
+        try:
+            return selfies_encoder(smiles)
+        except Exception:
+            print(f'Could not convert selfies {smiles} to SMILES.')

--- a/pytoda/smiles/smiles_language.py
+++ b/pytoda/smiles/smiles_language.py
@@ -243,7 +243,7 @@ class SMILESLanguage(object):
             token_indexes (Indexes): a sequence of token indexes.
 
         Returns:
-            str: a SMILES representation.
+            str: a SMILES (or SELFIES) representation.
         """
         return ''.join(
             [

--- a/pytoda/smiles/tests/test_smiles_language.py
+++ b/pytoda/smiles/tests/test_smiles_language.py
@@ -147,6 +147,18 @@ class TestSmilesLanguage(unittest.TestCase):
             smiles_language.token_indexes_to_smiles(token_indexes), 'CCO'
         )
 
+    def test_smiles_to_selfies(self) -> None:
+        """Test smiles_to_selfies and selfies_to_smiles"""
+        smiles = 'CCO'
+        smiles_language = SMILESLanguage()
+
+        self.assertEqual(
+            smiles,
+            smiles_language.selfies_to_smiles(
+                smiles_language.smiles_to_selfies(smiles)
+            )
+        )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Minor improvement. Associated methods to convert smiles to selfies and selfies to smiles to `SMILESLanguage` class.

I thought about it, but decided to keep `token_indexes_to_smiles` and `smiles_to_token_indexes` free from any SELFIES handling. If you work with SELFIES, then `smiles_to_token_indexes` expects SELFIES (not SMILES) and `token_indexes_to_smiles` will give you SELFIES (not SMILES). 