### PR TITLE
Minor improvements and fixes

### DIFF
--- a/pytoda/__init__.py
+++ b/pytoda/__init__.py
@@ -1,2 +1,2 @@
 name = 'pytoda'
-__version__ = '0.0.6'
+__version__ = '0.1'

--- a/pytoda/datasets/_smiles_dataset.py
+++ b/pytoda/datasets/_smiles_dataset.py
@@ -9,11 +9,11 @@ from ..smiles.processing import (
 import warnings
 from ..smiles.smiles_language import SMILESLanguage
 from ..smiles.transforms import (
-    Augment, Canonicalization, Kekulize, LeftPadding, NotKekulize, Randomize,
-    RemoveIsomery, Selfies, SMILESToTokenIndexes, ToTensor
+    Augment, Canonicalization, Kekulize, NotKekulize, RemoveIsomery, Selfies,
+    SMILESToTokenIndexes
 )
 from rdkit import Chem
-from ..transforms import Compose
+from ..transforms import Compose, ToTensor, Randomize, LeftPadding
 from ..types import FileList
 
 

--- a/pytoda/datasets/_smiles_dataset.py
+++ b/pytoda/datasets/_smiles_dataset.py
@@ -230,10 +230,10 @@ class _SMILESDataset(Dataset):
                 logger.warning(
                     f'Padding length of given SMILES Language was '
                     f'{self.padding_length}. Following a pass over the dataset'
-                    f'the padding length was updated to '
+                    f' the padding length was updated to '
                     f'{self.smiles_language.max_token_sequence_length}. If you'
-                    f'wish to fix the padding length, pass it directly to the '
-                    'constructor.'
+                    f' wish to fix the padding length, pass it directly to the'
+                    ' constructor.'
                 )
                 self.padding_length = (
                     self.smiles_language.max_token_sequence_length

--- a/pytoda/datasets/_smiles_dataset.py
+++ b/pytoda/datasets/_smiles_dataset.py
@@ -1,4 +1,6 @@
 """Implementation of _SMILESDataset."""
+import logging
+
 import torch
 from rdkit import Chem
 from torch.utils.data import Dataset
@@ -6,15 +8,15 @@ from torch.utils.data import Dataset
 from ..smiles.processing import (
     SMILES_TOKENIZER, tokenize_selfies, tokenize_smiles
 )
-import warnings
 from ..smiles.smiles_language import SMILESLanguage
 from ..smiles.transforms import (
     Augment, Canonicalization, Kekulize, NotKekulize, RemoveIsomery, Selfies,
     SMILESToTokenIndexes
 )
-from rdkit import Chem
-from ..transforms import Compose, ToTensor, Randomize, LeftPadding
+from ..transforms import Compose, LeftPadding, Randomize, ToTensor
 from ..types import FileList
+
+logger = logging.getLogger('pytoda_smiles_dataset')
 
 
 class _SMILESDataset(Dataset):
@@ -114,7 +116,7 @@ class _SMILESDataset(Dataset):
         # Set up transformation paramater
         self.padding = padding
         self.augment = augment
-        self.padding_length = self.padding_length = (
+        self.padding_length = (
             self.smiles_language.max_token_sequence_length
             if padding_length is None else padding_length
         )
@@ -179,7 +181,7 @@ class _SMILESDataset(Dataset):
             smiles_language is not None
             and len(self.language_transforms.transforms) == 0
         ):
-            print(
+            logger.warning(
                 'WARNING: You operate in the fast-setup regime.\nIf you pass a'
                 ' SMILESLanguage object, but dont specify any SMILES language'
                 ' transform, no pass is given over all SMILES in '
@@ -199,7 +201,7 @@ class _SMILESDataset(Dataset):
                     invalid_molecules.append(index)
             # Raise warning about invalid molecules
             if len(invalid_molecules) > 0:
-                print(
+                logger.warning(
                     f'NOTE: We found {len(invalid_molecules)} invalid smiles. '
                     'Check the warning trace. We recommend using '
                     'pytoda.preprocessing.smi.smi_cleaner to remove the '
@@ -208,7 +210,7 @@ class _SMILESDataset(Dataset):
 
             # Raise warning if new tokens were added.
             if len(self.smiles_language.token_to_index) > num_tokens:
-                print(
+                logger.warning(
                     f'{len(self.smiles_language.token_to_index) - num_tokens}'
                     ' new token(s) were added to SMILES language.'
                 )
@@ -220,7 +222,19 @@ class _SMILESDataset(Dataset):
         if self.randomize:
             transforms += [Randomize()]
         if self.padding:
-            if padding_length is None:
+            if (
+                padding_length is None
+                and self.smiles_language.max_token_sequence_length >
+                self.padding_length
+            ):
+                logger.warning(
+                    f'Padding length of given SMILES Language was '
+                    f'{self.padding_length}. Following a pass over the dataset'
+                    f'the padding length was updated to '
+                    f'{self.smiles_language.max_token_sequence_length}. If you'
+                    f'wish to fix the padding length, pass it directly to the '
+                    'constructor.'
+                )
                 self.padding_length = (
                     self.smiles_language.max_token_sequence_length
                 )

--- a/pytoda/datasets/protein_sequence_dataset.py
+++ b/pytoda/datasets/protein_sequence_dataset.py
@@ -3,13 +3,14 @@ import torch
 from torch.utils.data import Dataset
 
 from ..proteins.protein_language import ProteinLanguage
-from ..proteins.transforms import AugmentByReversing, SequenceToTokenIndexes
-from ..smiles.transforms import LeftPadding, Randomize, ToTensor
-from ..transforms import Compose
+from ..proteins.transforms import SequenceToTokenIndexes
+from ..transforms import (
+    AugmentByReversing, Compose, LeftPadding, Randomize, ToTensor
+)
 from ..types import FileList
+from ._fasta_eager_dataset import _FastaEagerDataset
 from ._smi_eager_dataset import _SmiEagerDataset
 from .utils import concatenate_file_based_datasets
-from ._fasta_eager_dataset import _FastaEagerDataset
 
 
 class ProteinSequenceDataset(Dataset):

--- a/pytoda/preprocessing/crawlers.py
+++ b/pytoda/preprocessing/crawlers.py
@@ -1,7 +1,10 @@
+import logging
 import urllib
 import urllib.error as urllib_error
 import urllib.request as urllib_request
 from typing import Union
+
+logger = logging.getLogger('pytoda_crawlers')
 
 ZINC_DRUG_SEARCH_ROOT = 'http://zinc.docking.org/substances/search/?q='
 ZINC_ID_SEARCH_ROOT = 'http://zinc.docking.org/substances/'
@@ -46,7 +49,7 @@ def get_smiles_from_zinc(drug: Union[str, int]) -> str:
             zinc_id = zinc_ids[0]
 
         except urllib_error.HTTPError:
-            print(f'Did not find any result for drug: {drug}')
+            logger.warninig(f'Did not find any result for drug: {drug}')
             return []
 
     elif type(drug) == int:
@@ -121,6 +124,6 @@ def get_smiles_from_pubchem(
             return smiles
         except urllib_error.HTTPError:
             if option == 'CanonicalSMILES':
-                print(f'Did not find any result for drug: {drug}')
+                logger.warninig(f'Did not find any result for drug: {drug}')
                 return []
             continue

--- a/pytoda/proteins/tests/test_protein_language.py
+++ b/pytoda/proteins/tests/test_protein_language.py
@@ -2,8 +2,6 @@
 import os
 import unittest
 
-from upfp import parse_fasta
-
 from pytoda.proteins.processing import IUPAC_VOCAB, UNIREP_VOCAB
 from pytoda.proteins.protein_language import ProteinLanguage
 from pytoda.tests.utils import TestFileContent

--- a/pytoda/proteins/transforms.py
+++ b/pytoda/proteins/transforms.py
@@ -1,6 +1,4 @@
 """Amino Acid Sequence transforms."""
-import random
-
 from ..transforms import Transform
 from ..types import Indexes
 from .protein_language import ProteinLanguage
@@ -29,19 +27,3 @@ class SequenceToTokenIndexes(Transform):
             Indexes: indexes representation for the Sequence provided.
         """
         return self.protein_language.sequence_to_token_indexes(smiles)
-
-
-class AugmentByReversing(Transform):
-    """Augment an amino acid sequence by (eventually) flipping order"""
-
-    def __call__(self, sequence: str) -> str:
-        """
-        Apply the transform.
-
-        Args:
-            sequnce (str): a sequence representation.
-
-        Returns:
-            str: Either the sequence itself, or the revesed sequence.
-        """
-        return sequence[::-1] if round(random.random()) else sequence

--- a/pytoda/smiles/smiles_language.py
+++ b/pytoda/smiles/smiles_language.py
@@ -1,11 +1,16 @@
 """SMILES language handling."""
-import dill
+import logging
 from collections import Counter
+
+import dill
+from selfies import decoder as selfies_decoder
+from selfies import encoder as selfies_encoder
+
 from ..files import read_smi
 from ..types import FileList, Indexes, SMILESTokenizer, Tokens
-from .processing import tokenize_smiles, SMILES_TOKENIZER
-from selfies import encoder as selfies_encoder
-from selfies import decoder as selfies_decoder
+from .processing import SMILES_TOKENIZER, tokenize_smiles
+
+logger = logging.getLogger('pytoda_smiles_language')
 
 
 class SMILESLanguage(object):
@@ -270,7 +275,11 @@ class SMILESLanguage(object):
         try:
             return selfies_decoder(selfies)
         except Exception:
-            print(f'Could not convert selfies {selfies} to SMILES.')
+            logger.warning(
+                f'Could not convert SELFIES {selfies} to SMILES, returning '
+                'the SELFIES instead'
+            )
+            return selfies
 
     def smiles_to_selfies(self, smiles: str) -> str:
         """
@@ -288,4 +297,8 @@ class SMILESLanguage(object):
         try:
             return selfies_encoder(smiles)
         except Exception:
-            print(f'Could not convert selfies {smiles} to SMILES.')
+            logger.warning(
+                f'Could not convert SMILES {smiles} to SELFIES, returning '
+                'the SMILES instead'
+            )
+            return smiles

--- a/pytoda/smiles/tests/test_transforms.py
+++ b/pytoda/smiles/tests/test_transforms.py
@@ -7,7 +7,8 @@ import torch
 
 from pytoda.smiles.smiles_language import SMILESLanguage
 from pytoda.smiles.transforms import (
-    AugmentTensor, Kekulize, NotKekulize, RemoveIsomery
+    AugmentTensor, Kekulize, NotKekulize, RemoveIsomery, LeftPadding,
+    SMILESToTokenIndexes
 )
 
 
@@ -196,6 +197,20 @@ class TestTransforms(unittest.TestCase):
             ground_truth += [smiles_language.padding_index
                              ] * (seq_len - len(ground_truth))
             self.assertEqual(augmented[ind].tolist(), ground_truth)
+
+    def test_left_padding(self) -> None:
+        """Test LeftPadding."""
+
+        padding_index = 0
+        padding_lengths = [8, 4]
+
+        # Molecules that are too long will be cut and a warning will be raised.
+        for padding_length in padding_lengths:
+            transform = LeftPadding(
+                padding_index=padding_index, padding_length=padding_length
+            )
+            for mol in ['C(N)CS', 'CCO']:
+                self.assertEqual(len(transform(list(mol))), padding_length)
 
 
 if __name__ == '__main__':

--- a/pytoda/smiles/tests/test_transforms.py
+++ b/pytoda/smiles/tests/test_transforms.py
@@ -1,14 +1,12 @@
 """Testing SMILES transforms."""
 import unittest
-import itertools
 
 import numpy as np
 import torch
 
 from pytoda.smiles.smiles_language import SMILESLanguage
 from pytoda.smiles.transforms import (
-    AugmentTensor, Kekulize, NotKekulize, RemoveIsomery, LeftPadding,
-    SMILESToTokenIndexes
+    AugmentTensor, Kekulize, NotKekulize, RemoveIsomery
 )
 
 
@@ -197,20 +195,6 @@ class TestTransforms(unittest.TestCase):
             ground_truth += [smiles_language.padding_index
                              ] * (seq_len - len(ground_truth))
             self.assertEqual(augmented[ind].tolist(), ground_truth)
-
-    def test_left_padding(self) -> None:
-        """Test LeftPadding."""
-
-        padding_index = 0
-        padding_lengths = [8, 4]
-
-        # Molecules that are too long will be cut and a warning will be raised.
-        for padding_length in padding_lengths:
-            transform = LeftPadding(
-                padding_index=padding_index, padding_length=padding_length
-            )
-            for mol in ['C(N)CS', 'CCO']:
-                self.assertEqual(len(transform(list(mol))), padding_length)
 
 
 if __name__ == '__main__':

--- a/pytoda/smiles/transforms.py
+++ b/pytoda/smiles/transforms.py
@@ -1,7 +1,6 @@
 """SMILES transforms."""
 import logging
 import re
-from copy import deepcopy
 
 import numpy as np
 import torch
@@ -15,7 +14,7 @@ from ..transforms import Transform
 from ..types import Indexes
 from .smiles_language import SMILESLanguage
 
-logger = logging.getLogger('SMILES_transforms')
+logger = logging.getLogger('pytoda_SMILES_transforms')
 
 
 class SMILESToTokenIndexes(Transform):
@@ -41,73 +40,6 @@ class SMILESToTokenIndexes(Transform):
             Indexes: indexes representation for the SMILES provided.
         """
         return self.smiles_language.smiles_to_token_indexes(smiles)
-
-
-class LeftPadding(Transform):
-    """Left pad token indexes."""
-
-    def __init__(self, padding_length: int, padding_index: int) -> None:
-        """
-        Initialize a left padding token indexes object.
-
-        Args:
-            padding_length (int): length of the padding.
-            padding_index (int): padding index.
-        """
-        self.padding_length = padding_length
-        self.padding_index = padding_index
-
-    def __call__(self, token_indexes: Indexes) -> Indexes:
-        """
-        Apply the transform.
-
-        Args:
-            token_indexes (Indexes): token indexes.
-
-        Returns:
-            Indexes: left padded indexes representation.
-        """
-        if self.padding_length < len(token_indexes):
-            logger.warning(
-                f'\n{token_indexes} is longer than padding length '
-                f'({self.padding_length}). End of string will be stripped off.'
-            )
-            return token_indexes[:self.padding_length]
-        else:
-            return (
-                (self.padding_length - len(token_indexes)) *
-                [self.padding_index] + token_indexes
-            )
-
-
-class ToTensor(Transform):
-    """Transform token indexes to torch tensor."""
-
-    def __init__(self, device, dtype=torch.short) -> None:
-        """
-        Initialize a token indexes to tensor object.
-
-        Args:
-            dtype (torch.dtype): data type. Defaults to torch.short.
-            device (torch.device): device where the tensors are stored.
-            Defaults to gpu, if available.
-        """
-        self.dtype = torch.short
-        self.device = device
-
-    def __call__(self, token_indexes: Indexes) -> torch.Tensor:
-        """
-        Apply the transform.
-
-        Args:
-            token_indexes (Indexes): token indexes.
-
-        Returns:
-            torch.Tensor: tensor representation of the token indexes.
-        """
-        return torch.tensor(
-            token_indexes, dtype=self.dtype, device=self.device
-        ).view(-1, 1).squeeze()
 
 
 class RemoveIsomery(Transform):
@@ -471,27 +403,6 @@ class AugmentTensor(Transform):
 
         augmented = torch.cat(augmented, dim=0)
         return augmented
-
-
-class Randomize(Transform):
-    """Randomize a molecule by truly shuffling all tokens."""
-
-    def __call__(self, tokens: Indexes) -> Indexes:
-        """
-        Intialize SMILES randomizer.
-
-        NOTE: Must not apply this transformation on SMILES string, only on the
-            tokenized, numerical vectors (i.e. after SMILESToTokenIndexes)
-
-        Args:
-            tokens (Indexes): indexes representation for the SMILES to be
-                randomized.
-        Returns:
-           Indexes: shuffled indexes representation of the molecule
-        """
-        smiles_tokens = deepcopy(tokens)
-        np.random.shuffle(smiles_tokens)
-        return smiles_tokens
 
 
 class Selfies(Transform):

--- a/pytoda/tests/test_transforms.py
+++ b/pytoda/tests/test_transforms.py
@@ -1,0 +1,25 @@
+"""Testing transforms."""
+import unittest
+from pytoda.transforms import LeftPadding
+
+
+class TestTransforms(unittest.TestCase):
+    """Testing transforms."""
+
+    def test_left_padding(self) -> None:
+        """Test LeftPadding."""
+
+        padding_index = 0
+        padding_lengths = [8]
+
+        # Molecules that are too long will be cut and a warning will be raised.
+        for padding_length in padding_lengths:
+            transform = LeftPadding(
+                padding_index=padding_index, padding_length=padding_length
+            )
+            for mol in ['C(N)CS', 'CCO']:
+                self.assertEqual(len(transform(list(mol))), padding_length)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/pytoda/tests/test_transforms.py
+++ b/pytoda/tests/test_transforms.py
@@ -10,7 +10,7 @@ class TestTransforms(unittest.TestCase):
         """Test LeftPadding."""
 
         padding_index = 0
-        padding_lengths = [8]
+        padding_lengths = [8, 4]
 
         # Molecules that are too long will be cut and a warning will be raised.
         for padding_length in padding_lengths:

--- a/pytoda/transforms.py
+++ b/pytoda/transforms.py
@@ -52,11 +52,17 @@ class LeftPadding(Transform):
         Returns:
             Indexes: left padded indexes representation.
         """
-
-        return (
-            (self.padding_length - len(token_indexes)) * [self.padding_index] +
-            token_indexes
-        )
+        if self.padding_length < len(token_indexes):
+            logger.warning(
+                f'\n{token_indexes} is longer than padding length '
+                f'({self.padding_length}). End of string will be stripped off.'
+            )
+            return token_indexes[:self.padding_length]
+        else:
+            return (
+                (self.padding_length - len(token_indexes)) *
+                [self.padding_index] + token_indexes
+            )
 
 
 class ToTensor(Transform):

--- a/pytoda/transforms.py
+++ b/pytoda/transforms.py
@@ -96,20 +96,19 @@ class ToTensor(Transform):
 
 
 class Randomize(Transform):
-    """Randomize a molecule by truly shuffling all tokens."""
+    """Randomize a sequence all tokens."""
 
     def __call__(self, tokens: Indexes) -> Indexes:
         """
-        Intialize SMILES randomizer.
-
-        NOTE: Must not apply this transformation on SMILES string, only on the
-            tokenized, numerical vectors (i.e. after SMILESToTokenIndexes)
-
         Args:
             tokens (Indexes): indexes representation for the SMILES to be
                 randomized.
         Returns:
            Indexes: shuffled indexes representation of the molecule
+
+        NOTE: If this transform is used on SMILES, it must not be applied on
+            the raw SMILES string, but on the tokenized, numerical vectors
+            (i.e. after SMILESToTokenIndexes).
         """
         smiles_tokens = deepcopy(tokens)
         np.random.shuffle(smiles_tokens)
@@ -117,7 +116,7 @@ class Randomize(Transform):
 
 
 class AugmentByReversing(Transform):
-    """Augment an amino acid sequence by (eventually) flipping order"""
+    """Augment an sequence by (eventually) flipping order"""
 
     def __call__(self, sequence: str) -> str:
         """

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ scripts = ['bin/pytoda-filter-invalid-smi']
 
 setup(
     name='pytoda',
-    version='0.0.6',
+    version='0.1',
     description='pytoda: PaccMann PyTorch Dataset Classes.',
     long_description=LONG_DESCRIPTION,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Several minor improvements and bugfixes:


- Fixing #27 - *Note*: There is an improved behavior in how `LeftPadding` deals sequences that are longer than the maximum length (aka `padding_length`). This affects `SMILESDataset`, `ProteinSequenceDataset` and all their child classes (@C-nit @niladell @gretamarkert @annaweber209). The new behavior is that the end of the sequence will be **stripped off**. This guarantees that all outputs have the same length and prevents downstream errors in tensor allocation or even in a network itself. 
- Fixing #38
- Fixing #39  - *Note*: The location of many transforms has changed. `LeftPadding`, `ToTensor` and `Randomize` were moved from `pytoda.smiles.transforms` into `pytoda.transforms` and `AugmentByReversing` was moved from `pytoda.proteins.transforms` into `pytoda.transforms` as these transforms are generic.
- changed verbosity from using `print`/`warninigs.warn` to `logging` statements.


