### PR TITLE
Smiles index handling

### DIFF
--- a/pytoda/smiles/processing.py
+++ b/pytoda/smiles/processing.py
@@ -21,7 +21,7 @@ with resources.path('pytoda.smiles.metadata', 'spe_chembl.txt') as filepath:
     SPE_TOKENIZER = SPE_Tokenizer(codecs.open(filepath))
 
 
-def tokenize_smiles(smiles: str, regexp=None) -> Tokens:
+def tokenize_smiles(smiles: str, regexp=None, *args, **kwargs) -> Tokens:
     """
     Tokenize a character-level SMILES string.
 

--- a/pytoda/smiles/smiles_language.py
+++ b/pytoda/smiles/smiles_language.py
@@ -232,9 +232,8 @@ class SMILESLanguage(object):
         """
         return self._finalize_token_indexes_fn(
             [
-                self.token_to_index[
-                    token if token in self.token_to_index else self.unknown_token
-                ]
+                self.token_to_index[token]
+                if token in self.token_to_index else self.unknown_index
                 for token in self.smiles_tokenizer(smiles)
             ]
         )

--- a/pytoda/smiles/tests/test_smiles_language.py
+++ b/pytoda/smiles/tests/test_smiles_language.py
@@ -93,6 +93,15 @@ class TestSmilesLanguage(unittest.TestCase):
         self.assertListEqual(
             smiles_language.smiles_to_token_indexes(smiles), token_indexes
         )
+        smiles_u = 'CCN'
+        token_indexes_u = [
+            smiles_language.token_to_index['C'],
+            smiles_language.token_to_index['C'], smiles_language.unknown_index
+        ]
+        self.assertListEqual(
+            smiles_language.smiles_to_token_indexes(smiles_u), token_indexes_u
+        )
+
         smiles_language = SMILESLanguage(add_start_and_stop=True)
         smiles_language.add_smiles(smiles)
         self.assertListEqual(


### PR DESCRIPTION
Fixing a bug in `smiles_to_token_indexes`:
When a SMILES with unknown tokens is passed, an error would be thrown since `self.unknown_index` does not occur in `self.token_to_index`.

Also adding a backwards compatability for the deprecated `normalize` arg in `tokenize_smiles`.  