### PR TITLE
fix: Enable sanitization in smiles dataset

### DIFF
--- a/pytoda/datasets/_smiles_dataset.py
+++ b/pytoda/datasets/_smiles_dataset.py
@@ -152,7 +152,10 @@ class _SMILESDataset(Dataset):
                         sanitize=self.sanitize
                     )
                 ]
-            elif self.all_bonds_explicit or self.all_hs_explicit:
+            elif (
+                self.all_bonds_explicit or self.all_hs_explicit
+                or self.sanitize
+            ):
                 language_transforms += [
                     NotKekulize(
                         all_bonds_explicit=self.all_bonds_explicit,


### PR DESCRIPTION
Fixing an unexpected behavior in SMILES dataset. If `sanitize` is set to True, sanitization is not performed unless other parameters are set to true also. This requires a change in your PR too @C-nit, particularly [here](https://github.com/PaccMann/paccmann_datasets/blob/68d7c4f28f505cd6590a6f1711e5256c2ff56ef9/pytoda/smiles/transforms.py#L78).

