### PR TITLE
selfies release and fixed vocab shipping

### DIFF
--- a/conda.yml
+++ b/conda.yml
@@ -12,7 +12,7 @@ dependencies:
     - torch==1.0.1
     - diskcache==4.1.0
     - dill==0.3.1.1
-    - selfies==0.2.4
+    - selfies==1.0.2
     - upfp==0.0.4
     - SmilesPE>=0.0.3
     - pyfaidx==0.5.8

--- a/pytoda/__init__.py
+++ b/pytoda/__init__.py
@@ -1,2 +1,2 @@
 name = 'pytoda'
-__version__ = '0.2.0'
+__version__ = '0.2.1'

--- a/pytoda/datasets/smiles_dataset.py
+++ b/pytoda/datasets/smiles_dataset.py
@@ -3,7 +3,7 @@ import logging
 
 import torch
 
-from ..smiles.processing import tokenize_selfies
+from ..smiles.processing import split_selfies
 from ..smiles.smiles_language import SMILESLanguage, SMILESTokenizer
 from ..types import Files
 from ._smi_eager_dataset import _SmiEagerDataset
@@ -159,7 +159,7 @@ class SMILESTokenizerDataset(DatasetDelegator):
             if selfies:
                 language_kwargs = dict(
                     name='selfies-language',
-                    smiles_tokenizer=tokenize_selfies
+                    smiles_tokenizer=split_selfies
                 )
             self.smiles_language = SMILESTokenizer(
                 **language_kwargs,

--- a/pytoda/proteins/protein_feature_language.py
+++ b/pytoda/proteins/protein_feature_language.py
@@ -1,8 +1,19 @@
 """Protein language handling."""
-from pytoda.smiles.processing import tokenize_selfies
 from .processing import AA_PROPERTIES_NUM, AA_FEAT, BLOSUM62
 from .protein_language import ProteinLanguage
 from ..types import Tokenizer
+
+
+class IndexesToSequenceError(Exception):
+    pass
+
+
+def token_indexes_to_sequence_raise(token_indexes: list) -> str:
+    """monkey patch to raise Error."""
+    raise IndexesToSequenceError(
+        'token_indexes_to_sequence not implemented for '
+        'binary_features since mapping is not unique.'
+    )
 
 
 class ProteinFeatureLanguage(ProteinLanguage):
@@ -37,6 +48,8 @@ class ProteinFeatureLanguage(ProteinLanguage):
 
         if self.feat == 'binary_features':
             self.token_to_index = AA_PROPERTIES_NUM
+            # monkey patching method
+            self.token_indexes_to_sequence = token_indexes_to_sequence_raise
         elif self.feat == 'float_features':
             self.token_to_index = AA_FEAT
         elif self.feat == 'blosum':
@@ -83,25 +96,6 @@ class ProteinFeatureLanguage(ProteinLanguage):
         self.start_index = self.token_to_index['<START>']
         self.stop_index = self.token_to_index['<STOP>']
 
-        if self.feat != 'binary_features':
-            self._token_indexes_to_sequence = lambda token_indexes: (
-                ''.join(
-                    [
-                        self.index_to_token.get(token_index, '')
-                        for token_index in token_indexes
-                        if token_index in self.sequence_tokens
-                    ]
-                )
-            )
-        else:
-            # Lambda function that throws an exception.
-            self._token_indexes_to_sequence = lambda x: (_ for _ in ()).throw(
-                Exception(
-                    'token_indexes_to_sequence not implemented for '
-                    'binary_features since mapping is not unique.'
-                )
-            )
-
     def sequence_to_token_indexes(self, sequence: str) -> list:
         """
         Transform character-level amino acid sequence (AAS) into a sequence of
@@ -132,4 +126,10 @@ class ProteinFeatureLanguage(ProteinLanguage):
         Returns:
             str: an amino acid sequence representation.
         """
-        return self._token_indexes_to_sequence(token_indexes)
+        return ''.join(
+            [
+                self.index_to_token.get(token_index, '')
+                for token_index in token_indexes
+                if token_index in self.sequence_tokens
+            ]
+        )

--- a/pytoda/smiles/processing.py
+++ b/pytoda/smiles/processing.py
@@ -2,11 +2,14 @@
 import codecs
 import logging
 import re
+import warnings
 from importlib import resources
 
-from ..types import Tokens, Tokenizer, Dict
 from SmilesPE.pretokenizer import kmer_tokenizer
 from SmilesPE.tokenizer import SPE_Tokenizer
+from selfies import split_selfies as split_selfies_
+
+from ..types import Dict, Tokenizer, Tokens
 
 logger = logging.getLogger(__name__)
 
@@ -90,6 +93,10 @@ def tokenize_selfies(selfies: str) -> Tokens:
     Returns:
         Tokens: the tokenized SELFIES.
     """
+    warnings.warn(
+        "tokenize_selfies will be deprecated in favor of ",
+        DeprecationWarning
+    )
     try:
         selfies = selfies.replace('.', '[.]')  # to allow parsing unbound atoms
         selfies_char_list_pre = selfies[1:-1].split('][')
@@ -102,9 +109,21 @@ def tokenize_selfies(selfies: str) -> Tokens:
         return ['']
 
 
+def split_selfies(selfies: str) -> Tokens:
+    """Tokenize SELFIES, wrapping generator method from selfies package.
+
+    Args:
+        selfies (str): a SELFIES representation (character-level).
+
+    Returns:
+        Tokens: the tokenized SELFIES.
+    """
+    return list(split_selfies_(selfies))
+
+
 TOKENIZER_FUNCTIONS: Dict[str, Tokenizer] = {
     'smiles': tokenize_smiles,
     'kmer_smiles': kmer_smiles_tokenizer,
     'spe_smiles': spe_smiles_tokenizer,
-    'selfies': tokenize_selfies,
+    'selfies': split_selfies,
 }

--- a/pytoda/smiles/processing.py
+++ b/pytoda/smiles/processing.py
@@ -23,7 +23,9 @@ with resources.path('pytoda.smiles.metadata', 'spe_chembl.txt') as filepath:
     SPE_TOKENIZER = SPE_Tokenizer(codecs.open(filepath))
 
 
-def tokenize_smiles(smiles: str, regexp=SMILES_TOKENIZER, *args, **kwargs) -> Tokens:
+def tokenize_smiles(
+    smiles: str, regexp=SMILES_TOKENIZER, *args, **kwargs
+) -> Tokens:
     """
     Tokenize a character-level SMILES string.
 
@@ -94,7 +96,7 @@ def tokenize_selfies(selfies: str) -> Tokens:
         Tokens: the tokenized SELFIES.
     """
     warnings.warn(
-        "tokenize_selfies will be deprecated in favor of ",
+        "tokenize_selfies will be deprecated in favor of `split_selfies`",
         DeprecationWarning
     )
     try:
@@ -110,7 +112,7 @@ def tokenize_selfies(selfies: str) -> Tokens:
 
 
 def split_selfies(selfies: str) -> Tokens:
-    """Tokenize SELFIES, wrapping generator method from selfies package.
+    """Tokenize SELFIES, wrapping generator as list.
 
     Args:
         selfies (str): a SELFIES representation (character-level).

--- a/pytoda/smiles/tests/test_polymer_language.py
+++ b/pytoda/smiles/tests/test_polymer_language.py
@@ -4,7 +4,7 @@ import tempfile
 import unittest
 
 from pytoda.smiles.polymer_language import PolymerTokenizer
-from pytoda.smiles.processing import tokenize_selfies
+from pytoda.smiles.processing import split_selfies
 from pytoda.smiles.transforms import Selfies
 from pytoda.tests.utils import TestFileContent
 
@@ -106,7 +106,7 @@ class TestPolymerTokenizer(unittest.TestCase):
         # SELFIES
         polymer_language = PolymerTokenizer(
             entity_names=entities,
-            smiles_tokenizer=lambda selfies: tokenize_selfies(selfies)
+            smiles_tokenizer=split_selfies
         )
         transform = Selfies()
         selfies = transform(smiles)

--- a/pytoda/smiles/tests/test_smiles_language.py
+++ b/pytoda/smiles/tests/test_smiles_language.py
@@ -3,7 +3,7 @@ import os
 import tempfile
 import unittest
 
-from pytoda.smiles.processing import tokenize_selfies
+from pytoda.smiles.processing import split_selfies
 from pytoda.smiles.smiles_language import (SELFIESLanguage, SMILESLanguage,
                                            SMILESTokenizer)
 from pytoda.smiles.transforms import Selfies
@@ -122,7 +122,7 @@ class TestSmilesLanguage(unittest.TestCase):
 
         # SELFIES
         smiles_language = SMILESLanguage(
-            smiles_tokenizer=lambda selfies: tokenize_selfies(selfies)
+            smiles_tokenizer=split_selfies
         )
         transform = Selfies()
         selfies = transform(smiles)
@@ -137,7 +137,7 @@ class TestSmilesLanguage(unittest.TestCase):
         )
         smiles_language = SMILESTokenizer(
             add_start_and_stop=True,
-            smiles_tokenizer=lambda selfies: tokenize_selfies(selfies)
+            smiles_tokenizer=split_selfies
         )
         smiles_language.add_smiles(selfies)
         self.assertListEqual(

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pandas==1.1.3
 torch==1.6.0
 diskcache==5.0.3
 dill==0.3.2
-selfies==0.2.4
+selfies==1.0.2
 upfp==0.0.5
 SmilesPE>=0.0.3
 pyfaidx==0.5.9.1

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,9 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],
     packages=find_packages(),
-    package_data={'pytoda': ['smiles/metadata/*']},
+    package_data={'pytoda.smiles.metadata': [
+        'spe_chembl.txt', 'ATTRIBUTION', 'README.md',
+        'tokenizer_chembl_gdsc_ccle_tox21_zinc_organdb_bindingdb'
+    ]},
     scripts=scripts
 )

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     license='MIT',
     install_requires=[
         'numpy', 'scikit-learn', 'pandas', 'torch>=1.0.0', 'diskcache', 'dill',
-        'selfies', 'upfp', 'SmilesPE>=0.0.3', 'pyfaidx'
+        'selfies>=1.0.2', 'upfp', 'SmilesPE>=0.0.3', 'pyfaidx'
     ],
     classifiers=[
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     packages=find_packages(),
     package_data={'pytoda.smiles.metadata': [
         'spe_chembl.txt', 'ATTRIBUTION', 'README.md',
-        'tokenizer_chembl_gdsc_ccle_tox21_zinc_organdb_bindingdb'
+        'tokenizer_chembl_gdsc_ccle_tox21_zinc_organdb_bindingdb/*'
     ]},
     scripts=scripts
 )


### PR DESCRIPTION
 - Updated tests for release version of selfies package.
 - Added deprecation warning to `tokenize_selfies` in favor of offical `split_selfies`, that is the new selfies default.
The above resolve #81.
- Fixed package data inclusion for pretrained tokenizer.
- Minor refactor in `ProteinFeatureLanguage`.
