### PR TITLE
chore: conda.yml referring to requirements.txt.

### DIFF
--- a/conda.yml
+++ b/conda.yml
@@ -6,13 +6,4 @@ dependencies:
   - python>=3.7,<3.8
   - pip>=19.1
   - pip:
-    - numpy==1.16.1
-    - scikit-learn==0.21.3
-    - pandas==0.25.2
-    - torch==1.0.1
-    - diskcache==4.1.0
-    - dill==0.3.1.1
-    - selfies==1.0.2
-    - upfp==0.0.4
-    - SmilesPE>=0.0.3
-    - pyfaidx==0.5.8
+    - -r file:requirements.txt


### PR DESCRIPTION
This leaves only one place for us to pin exact versions. In particular, pyup-bot version bumps need not be tracked in the conda.yml.