### PR TITLE
fix: Bug in filetype parsing of PPI Dataset

### DIFF
--- a/pytoda/datasets/protein_protein_interaction_dataset.py
+++ b/pytoda/datasets/protein_protein_interaction_dataset.py
@@ -97,7 +97,7 @@ class ProteinProteinInteractionDataset(Dataset):
         #  Data type of first sequence files per entity
         if sequence_filetypes == 'infer':
             self.filetypes = list(
-                map(lambda x: '.' + x[0].split('.')[-1], sequence_filepaths)
+                map(lambda x: '.' + x[0].split('.')[-1], self.sequence_filepaths)
             )
         elif sequence_filetypes in ['.smi', '.csv', '.fasta', '.fasta.gz']:
             self.filetypes = [sequence_filetypes] * len(self.entities)
@@ -211,16 +211,16 @@ class ProteinProteinInteractionDataset(Dataset):
 
     def __getitem__(self, index: int) -> Tuple[Tensor, ...]:
         """
-            Generates one sample of data.
+        Generates one sample of data.
 
-            Args:
-                index (int): index of the sample to fetch.
+        Args:
+            index (int): index of the sample to fetch.
 
-            Returns:
-                Tuple: a tuple containing self.entities+1 torch.Tensors
-                representing respectively: compound token indexes for each
-                protein entity and the property labels (annotations)
-            """
+        Returns:
+            Tuple: a tuple containing self.entities+1 torch.Tensors
+            representing respectively: compound token indexes for each
+            protein entity and the property labels (annotations)
+        """
 
         # sample selection
         selected_sample = self.labels_df.iloc[index]

--- a/pytoda/datasets/tests/test_protein_protein_interaction_dataset.py
+++ b/pytoda/datasets/tests/test_protein_protein_interaction_dataset.py
@@ -27,8 +27,8 @@ class TestProteinProteinInteractionDataset(unittest.TestCase):
             ]
         )
 
-        with TestFileContent(content_entity_1, '.smi') as a_test_file:
-            with TestFileContent(content_entity_2, '.smi') as another_test_file:
+        with TestFileContent(content_entity_1, suffix='.smi') as a_test_file:
+            with TestFileContent(content_entity_2, suffix='.smi') as another_test_file:
                 with TestFileContent(annotated_content) as annotation_file:
 
                     for sequence_filetype in ['.smi', 'infer']:

--- a/pytoda/datasets/tests/test_protein_protein_interaction_dataset.py
+++ b/pytoda/datasets/tests/test_protein_protein_interaction_dataset.py
@@ -27,15 +27,17 @@ class TestProteinProteinInteractionDataset(unittest.TestCase):
             ]
         )
 
-        with TestFileContent(content_entity_1) as a_test_file:
-            with TestFileContent(content_entity_2) as another_test_file:
+        with TestFileContent(content_entity_1, '.smi') as a_test_file:
+            with TestFileContent(content_entity_2, '.smi') as another_test_file:
                 with TestFileContent(annotated_content) as annotation_file:
-                    ppi_dataset = ProteinProteinInteractionDataset(
-                        [a_test_file.filename, another_test_file.filename],
-                        ['tcr', 'peptide'],
-                        annotation_file.filename,
-                        sequence_filetypes='.smi',
-                    )
+
+                    for sequence_filetype in ['.smi', 'infer']:
+                        ppi_dataset = ProteinProteinInteractionDataset(
+                            [a_test_file.filename, another_test_file.filename],
+                            ['tcr', 'peptide'],
+                            annotation_file.filename,
+                            sequence_filetypes=sequence_filetype,
+                        )
 
                     self.assertEqual(len(ppi_dataset), 3)
 

--- a/pytoda/tests/utils.py
+++ b/pytoda/tests/utils.py
@@ -10,14 +10,17 @@ class TestFileContent:
     Inspired by: https://stackoverflow.com/a/54053967/10032558.
     """
 
-    def __init__(self, content: str, suffix: str = None) -> None:
+    def __init__(self, content: str, **kwargs) -> None:
         """
         Initialize the file with a content.
 
         Args:
             content (str): content of the file.
+            **kwargs (dict): Additional keyword arguments for NamedTemporaryFile.
+                NOTE: This can e.g. be suffix='.csv' if the temporary filename should
+                adhere to a specific suffix.
         """
-        self.file = tempfile.NamedTemporaryFile(mode='w', delete=False, suffix=suffix)
+        self.file = tempfile.NamedTemporaryFile(mode='w', delete=False, **kwargs)
         with self.file as fp:
             fp.write(content)
 

--- a/pytoda/tests/utils.py
+++ b/pytoda/tests/utils.py
@@ -10,14 +10,14 @@ class TestFileContent:
     Inspired by: https://stackoverflow.com/a/54053967/10032558.
     """
 
-    def __init__(self, content: str) -> None:
+    def __init__(self, content: str, suffix: str = None) -> None:
         """
         Initialize the file with a content.
 
         Args:
             content (str): content of the file.
         """
-        self.file = tempfile.NamedTemporaryFile(mode='w', delete=False)
+        self.file = tempfile.NamedTemporaryFile(mode='w', delete=False, suffix=suffix)
         with self.file as fp:
             fp.write(content)
 


### PR DESCRIPTION
kudos to @annaweber209 for finding a bug in `ProteinProteinInteractionDataset`.

**Problems**
- In `ProteinProteinInteractionDataset` when the mode of the `sequence_filepaths` is set to `infer`, it should infer the suffix of files automatically. The bug is that in a map wrapping `sequence_filepaths` is used instead of `self.sequence_filepaths`
- This was particularly bad since this case was not covered by tests although `infer` mode is the default. Tests covered only cases where the mode was explicity set to `.smi`.
- Unfortunately the `TestFileContent` class created under `pytoda.tests.utils` did not allow to pass in a suffix for the temporary filepath which makes it impossible to compute a test for it

**Fixes**
- This PR fixes the bug in `ProteinProteinInteractionDataset` 
- This PR adds a test for `ProteinProteinInteractionDataset` that now both modes run through.
- This PR introduces a change in `TestFileContent` to allow to optionally pass an suffix for a temporary filepath.

_Warning_: There may be other parts of the repo where we infer filepath types which are not covered. Any idea @C-nit ?
