### PR TITLE
Multi protein languages

### DIFF
--- a/pytoda/datasets/protein_protein_interaction_dataset.py
+++ b/pytoda/datasets/protein_protein_interaction_dataset.py
@@ -151,12 +151,12 @@ class ProteinProteinInteractionDataset(Dataset):
                     f'Received unknown type for protein_language: {type(protein_languages)}'
                 )
             # Check whether input arguments are consistent
-            for i, (l, s) in enumerate(
+            for i, (lang, start) in enumerate(
                 zip(self.protein_languages, self.add_start_and_stops)
             ):
                 assert (
-                    l.add_start_and_stop == s
-                ), f'add_start_and_stop differs for language {i}: {s} vs. {l.add_start_and_stop}'
+                    lang.add_start_and_stop == start
+                ), f'add_start_and_stop differs for language {i}: {start} vs. {lang.add_start_and_stop}'
 
         # Create protein sequence datasets.
         self.datasets = [
@@ -175,7 +175,7 @@ class ProteinProteinInteractionDataset(Dataset):
             for index, filepaths in enumerate(self.sequence_filepaths)
         ]
         # Retrieve the possibly updated protein languages
-        self.protein_languages = [d.protein_language for d in self.datasets]
+        self.protein_languages = [data.protein_language for data in self.datasets]
 
         # Labels
         self.labels_df = pd.read_csv(self.labels_filepath)

--- a/pytoda/datasets/protein_protein_interaction_dataset.py
+++ b/pytoda/datasets/protein_protein_interaction_dataset.py
@@ -24,8 +24,7 @@ class ProteinProteinInteractionDataset(Dataset):
         labels_filepath: str,
         sequence_filetypes: Union[str, List[str]] = 'infer',
         annotations_column_names: Union[List[int], List[str]] = None,
-        protein_language: ProteinLanguage = None,
-        amino_acid_dict: str = 'iupac',
+        protein_languages: Union[ProteinLanguage, List[ProteinLanguage]] = None,
         paddings: Union[bool, Sequence[bool]] = True,
         padding_lengths: Union[int, Sequence[int]] = None,
         add_start_and_stops: Union[bool, Sequence[bool]] = False,
@@ -62,12 +61,12 @@ class ProteinProteinInteractionDataset(Dataset):
                 (positional or strings) for the annotations. Defaults to None,
                 a.k.a. all the columns, except the entity_names are annotation
                 labels.
-            protein_language (ProteinLanguage): a ProteinLanguage (or child)
-                instance, e.g. ProteinFeatureLanguage. Defaults to None,
-                creating a default instance.
-            amino_acid_dict (str): The type of amino acid dictionary to map
-                each sequence token to a unique number. Defaults to 'iupac', alternative
-                is 'unirep'.
+            protein_languages (Union[ProteinLanguage, List[ProteinLanguage]):
+                one or multiple ProteinLanguages. If multiple are provided, exactly one
+                should be given for each entity. If only one is provided, the same
+                language will be used for all entities. You can also pass child instances
+                like ProteinFeatureLanguage. Defaults to None, i.e., creating a single
+                protein language with iupac dictionary for all entities.
             paddings (Union[bool, Sequence[bool]]): pad sequences to longest in
                 the protein language. Defaults to True.
             padding_lengths (Union[int, Sequence[int]]): manually sets number
@@ -132,25 +131,39 @@ class ProteinProteinInteractionDataset(Dataset):
             ),
         )
 
-        if protein_language is None:
-            self.protein_language = ProteinLanguage()
-
+        if protein_languages is None:
+            # Objects will be constructed in `ProteinSequenceDataset`
+            self.protein_languages = [None for _ in self.entities]
+            self.pl_methods = ['iupac' for _ in self.entities]
         else:
-            self.protein_language = protein_language
-            assert (
-                self.protein_language.add_start_and_stop
-                == all(self.add_start_and_stops)
-            ) and all(self.add_start_and_stops) == any(
-                self.add_start_and_stops
-            ), 'Inconsistencies found in add_start_and_stop.'
+            if isinstance(protein_languages, Sequence):
+                # Multiple languages were passed
+                self.protein_languages = protein_languages
+                self.pl_methods = [p.method for p in protein_languages]
 
-        # Create protein sequence datasets
+            elif isinstance(protein_languages, ProteinLanguage):
+                # Single language was passed
+                self.protein_languages = [protein_languages for _ in self.entities]
+                self.pl_methods = [protein_languages.method for _ in self.entities]
+
+            else:
+                raise TypeError(
+                    f'Received unknown type for protein_language: {type(protein_languages)}'
+                )
+            # Check whether input arguments are consistent
+            for i, (l, s) in enumerate(
+                zip(self.protein_languages, self.add_start_and_stops)
+            ):
+                assert (
+                    l.add_start_and_stop == s
+                ), f'add_start_and_stop differs for language {i}: {s} vs. {l.add_start_and_stop}'
+
+        # Create protein sequence datasets.
         self.datasets = [
             ProteinSequenceDataset(
                 *filepaths,
                 filetype=self.filetypes[index],
-                protein_language=protein_language,
-                amino_acid_dict=amino_acid_dict,
+                protein_language=self.protein_languages[index],
                 padding=self.paddings[index],
                 padding_length=self.padding_lengths[index],
                 add_start_and_stop=self.add_start_and_stops[index],
@@ -161,6 +174,9 @@ class ProteinProteinInteractionDataset(Dataset):
             )
             for index, filepaths in enumerate(self.sequence_filepaths)
         ]
+        # Retrieve the possibly updated protein languages
+        self.protein_languages = [d.protein_language for d in self.datasets]
+
         # Labels
         self.labels_df = pd.read_csv(self.labels_filepath)
         # Cast the column names to uppercase

--- a/pytoda/datasets/protein_sequence_dataset.py
+++ b/pytoda/datasets/protein_sequence_dataset.py
@@ -141,8 +141,8 @@ class ProteinSequenceDataset(DatasetDelegator):
             protein_language (ProteinLanguage): a ProteinLanguage (or child)
                 instance, e.g. ProteinFeatureLanguage. Defaults to None,
                 creating a default instance.
-            amino_acid_dict (str): Type of dictionary used for amino acid
-                sequences. Defaults to 'iupac', alternative is 'unirep'.
+            amino_acid_dict (str): Type of dictionary used for amino acid sequences.
+                Defaults to 'iupac', alternative is 'unirep' or 'human-kinase-alignment'
             padding (bool): pad sequences to longest in the protein language.
                 Defaults to True.
             padding_length (int): manually sets number of applied paddings,

--- a/pytoda/proteins/protein_feature_language.py
+++ b/pytoda/proteins/protein_feature_language.py
@@ -85,3 +85,8 @@ class ProteinFeatureLanguage(ProteinLanguage):
                 if token_index in self.sequence_tokens
             ]
         )
+
+    @property
+    def method(self) -> str:
+        """A string denoting the language encoding method"""
+        return self.feat

--- a/pytoda/proteins/protein_language.py
+++ b/pytoda/proteins/protein_language.py
@@ -251,3 +251,8 @@ class ProteinLanguage(object):
                 if token_index in self.sequence_tokens
             ]
         )
+
+    @property
+    def method(self) -> str:
+        """A string denoting the language method"""
+        return self.dict

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-numpy>=1.18.0
-scikit-learn>=0.21.0
+numpy>=1.20.0
+scikit-learn>=0.23.0
 pandas>=1.0.0
 torch<1.9>=1.4.0
 diskcache>=5.0.3
@@ -7,7 +7,7 @@ dill>=0.3.0
 selfies>=2.0.0
 upfp>=0.0.5
 SmilesPE>=0.0.3
-pyfaidx>=0.5.0
+pyfaidx>=0.6.0
 PubChemPy>=1.0.4
 importlib_resources>=5.2.2
 Unidecode>=1.1.2


### PR DESCRIPTION
Providing the feature requested in #133. User can now pass a single or multiple protein languages or protein feature languages when working with the PPI dataset. Also mixtures of both languages are supported.

Addendum: Increasing some package versions in accordance with codiga recommendations