### PR TITLE
PyPI Release

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,23 @@
+name: Upload Python Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine
+      - name: Build and publish
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          python setup.py sdist bdist_wheel
+          twine upload --skip-existing dist/*

--- a/README.md
+++ b/README.md
@@ -4,21 +4,28 @@
 [![Code quality](https://api.codiga.io/project/22043/score/svg)](https://codiga.io/)
 [![Code grade](https://api.codiga.io/project/22043/status/svg)](https://codiga.io/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![Downloads](https://pepy.tech/badge/pytoda)](https://pepy.tech/project/pytoda)
+[![Downloads](https://pepy.tech/badge/pytoda/month)](https://pepy.tech/project/pytoda)
 
 ## Overview
 
 pytoda - PaccMann P*yTo*rch *Da*taset Classes
 
 A python package that eases handling biochemical data for deep learning applications with pytorch.
-Please find the full documentation [here](https://paccmann.github.io/paccmann_datasets/).
-
-## Requirements
-
-- `conda>=3.7`
 
 ## Installation
 
-Create a conda environment:
+`pytoda` ships via [PyPI](https://pypi.org/project/pytoda):
+```sh
+pip install pytoda
+```
+## Documentation
+
+Please find the full documentation [here](https://paccmann.github.io/paccmann_datasets/).
+
+## Development
+
+For development setup, we recommend to work in a dedicated conda environment:
 
 ```sh
 conda env create -f conda.yml
@@ -30,20 +37,16 @@ Activate the environment:
 conda activate pytoda
 ```
 
-Install:
-
-```sh
-pip install .
-```
-
-### development
-
-Create the `conda` environment as before, then install in editable mode for development:
+Install in editable mode:
 
 ```sh
 pip install -r dev_requirements.txt
 pip install --user --no-use-pep517 -e .
 ```
+#### Note on `rdkit` vs `rdkit-pypi`
+NOTE: The conda env ships with the [*official*](https://github.com/rdkit/rdkit) `rdkit` implementation.
+But the `pip` installation overwrites the rdkit package with the community-contributed [PyPI package](https://pypi.org/project/rdkit-pypi/#history) called `rdkit-pypi`. This is intentional because `pytoda` is distributed via PyPI too and most users will thus depend on `rdkit-pypi`. Keep in mind that `rdkit-pypi` might contain bugs or be outdated w.r.t. `rdkit`. If developers experience issues with `rdkit-pypi`, they can temporarily uninstall `rdkit-pypi` and will then fall back on using the proper `rdkit` package.
+
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # pytoda
+[![PyPI version](https://badge.fury.io/py/pytoda.svg)](https://badge.fury.io/py/pytoda)
 [![build](https://github.com/PaccMann/paccmann_datasets/workflows/build/badge.svg)](https://github.com/PaccMann/paccmann_datasets/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Code quality](https://api.codiga.io/project/22043/score/svg)](https://codiga.io/)
@@ -19,6 +20,7 @@ A python package that eases handling biochemical data for deep learning applicat
 ```sh
 pip install pytoda
 ```
+
 ## Documentation
 
 Please find the full documentation [here](https://paccmann.github.io/paccmann_datasets/).
@@ -43,7 +45,8 @@ Install in editable mode:
 pip install -r dev_requirements.txt
 pip install --user --no-use-pep517 -e .
 ```
-#### Note on `rdkit` vs `rdkit-pypi`
+
+### Note on `rdkit` vs `rdkit-pypi`
 NOTE: The conda env ships with the [*official*](https://github.com/rdkit/rdkit) `rdkit` implementation.
 But the `pip` installation overwrites the rdkit package with the community-contributed [PyPI package](https://pypi.org/project/rdkit-pypi/#history) called `rdkit-pypi`. This is intentional because `pytoda` is distributed via PyPI too and most users will thus depend on `rdkit-pypi`. Keep in mind that `rdkit-pypi` might contain bugs or be outdated w.r.t. `rdkit`. If developers experience issues with `rdkit-pypi`, they can temporarily uninstall `rdkit-pypi` and will then fall back on using the proper `rdkit` package.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # pytoda
+
 [![PyPI version](https://badge.fury.io/py/pytoda.svg)](https://badge.fury.io/py/pytoda)
 [![build](https://github.com/PaccMann/paccmann_datasets/workflows/build/badge.svg)](https://github.com/PaccMann/paccmann_datasets/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
@@ -7,16 +8,19 @@
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Downloads](https://pepy.tech/badge/pytoda)](https://pepy.tech/project/pytoda)
 [![Downloads](https://pepy.tech/badge/pytoda/month)](https://pepy.tech/project/pytoda)
+[![GitHub Super-Linter](https://github.com/PaccMann/paccmann_datasets/workflows/style/badge.svg)](https://github.com/marketplace/actions/super-linter)
 
 ## Overview
 
 pytoda - PaccMann P*yTo*rch *Da*taset Classes
 
-A python package that eases handling biochemical data for deep learning applications with pytorch.
+A python package that eases handling biochemical data for deep learning applications
+with pytorch.
 
 ## Installation
 
 `pytoda` ships via [PyPI](https://pypi.org/project/pytoda):
+
 ```sh
 pip install pytoda
 ```
@@ -47,9 +51,16 @@ pip install --user --no-use-pep517 -e .
 ```
 
 ### Note on `rdkit` vs `rdkit-pypi`
-NOTE: The conda env ships with the [*official*](https://github.com/rdkit/rdkit) `rdkit` implementation.
-But the `pip` installation overwrites the rdkit package with the community-contributed [PyPI package](https://pypi.org/project/rdkit-pypi/#history) called `rdkit-pypi`. This is intentional because `pytoda` is distributed via PyPI too and most users will thus depend on `rdkit-pypi`. Keep in mind that `rdkit-pypi` might contain bugs or be outdated w.r.t. `rdkit`. If developers experience issues with `rdkit-pypi`, they can temporarily uninstall `rdkit-pypi` and will then fall back on using the proper `rdkit` package.
 
+NOTE: The conda env ships with the [*official*](https://github.com/rdkit/rdkit) `rdkit`
+implementation. But the `pip` installation overwrites the rdkit package with the
+community-contributed [PyPI package](https://pypi.org/project/rdkit-pypi/#history)
+called `rdkit-pypi`.
+This is intentional because `pytoda` is distributed via PyPI too and most users will
+thus depend on `rdkit-pypi`. Keep in mind that `rdkit-pypi` might contain bugs or
+be outdated wrt `rdkit`. If developers experience issues with `rdkit-pypi`,
+they can temporarily uninstall `rdkit-pypi` and will then fall back on using
+the proper `rdkit` package.
 
 ## Examples
 
@@ -61,19 +72,30 @@ If you use `pytoda` in your projects, please cite the following:
 
 ```bib
 @article{born2021datadriven,
-  author = {Born, Jannis and Manica, Matteo and Cadow, Joris and Markert, Greta and Mill, Nil Adell and Filipavicius, Modestas and Janakarajan, Nikita and Cardinale, Antonio and Laino, Teodoro and {Rodr{\'{i}}guez Mart{\'{i}}nez}, Mar{\'{i}}a},
+  author = {
+    Born, Jannis and Manica, Matteo and Cadow, Joris and Markert, Greta and
+    Mill,Nil Adell and Filipavicius, Modestas and Janakarajan, Nikita and
+    Cardinale, Antonio and Laino, Teodoro and 
+    {Rodr{\'{i}}guez Mart{\'{i}}nez}, Mar{\'{i}}a
+  },
   doi = {10.1088/2632-2153/abe808},
   issn = {2632-2153},
   journal = {Machine Learning: Science and Technology},
   number = {2},
   pages = {025024},
-  title = {{Data-driven molecular design for discovery and synthesis of novel ligands: a case study on SARS-CoV-2}},
+  title = {{
+    Data-driven molecular design for discovery and synthesis of novel ligands: 
+    a case study on SARS-CoV-2
+  }},
   url = {https://iopscience.iop.org/article/10.1088/2632-2153/abe808},
   volume = {2},
   year = {2021}
 }
 @article{born2021paccmannrl,
-    title = {PaccMann$^{RL}$: De novo generation of hit-like anticancer molecules from transcriptomic data via reinforcement learning},
+    title = {
+      PaccMann$^{RL}$: De novo generation of hit-like anticancer molecules from
+      transcriptomic data via reinforcement learning
+    },
     journal = {iScience},
     volume = {24},
     number = {4},
@@ -81,6 +103,9 @@ If you use `pytoda` in your projects, please cite the following:
     issn = {2589-0042},
     doi = {https://doi.org/10.1016/j.isci.2021.102269},
     url = {https://www.cell.com/iscience/fulltext/S2589-0042(21)00237-6},
-    author = {Jannis Born and Matteo Manica and Ali Oskooei and Joris Cadow and Greta Markert and Mar{\'\i}a Rodr{\'\i}guez Mart{\'\i}nez}}
+    author = {
+      Jannis Born and Matteo Manica and Ali Oskooei and Joris Cadow and Greta Markert
+      and Mar{\'\i}a Rodr{\'\i}guez Mart{\'\i}nez}
+    }
 }
 ```

--- a/pytoda/__init__.py
+++ b/pytoda/__init__.py
@@ -1,2 +1,2 @@
 name = 'pytoda'
-__version__ = '0.2.5'
+__version__ = '1.0.0'

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pyfaidx>=0.6.0
 PubChemPy>=1.0.4
 importlib_resources>=5.2.2
 Unidecode>=1.1.2
+rdkit-pypi>=2021.9.3

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
         'pubchempy',
         'importlib_resources',
         'Unidecode',
+        'rdkit-pypi>=2021.9.3',
     ],
     classifiers=[
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -33,11 +33,8 @@ setup(
     description='pytoda: PaccMann PyTorch Dataset Classes.',
     long_description=LONG_DESCRIPTION,
     long_description_content_type='text/markdown',
-    author='Matteo Manica, Jannis Born, Ali Oskooei, Joris Cadow',
-    author_email=(
-        'drugilsberg@gmail.com, jab@zurich.ibm.com, '
-        'ali.oskooei@gmail.com, joriscadow@gmail.com'
-    ),
+    author='Matteo Manica, Jannis Born, Joris Cadow',
+    author_email='drugilsberg@gmail.com, jannis.born@gmx.de, joriscadow@gmail.com',
     url='https://github.com/PaccMann/paccmann_datasets',
     license='MIT',
     install_requires=[


### PR DESCRIPTION
Preparing the release of pytoda 1.0.0 and the making it available via pypi. This closes #138 
I added a workflow for uploading the code on pypi side whenever a release is triggered on our side.

Questions:
- Versioning convention 1.0.0 instead of v1.0.0 is ok?
- The repo is called _paccmann_datasets_ but the package should be _pytoda_. Usually repo and package name are identical. Do you know whether we have to change the repo name or we can pass a flag to twine? Renaming the repo would not be great since all our paper code refers to https://github.com/PaccMann/paccmann_datasets. 

The first release will integrate some changes I did yesterday. **Those PRs were merged without any Reviews**
#144 / #145
#146
#147 
#148

Also, I closed some existing issues without significant work on them: 
#36 #61 #105 #98 